### PR TITLE
fix: correct tool count (18→17) and add missing palinode_prompt tool

### DIFF
--- a/docs/INSTALL-CLAUDE-CODE.md
+++ b/docs/INSTALL-CLAUDE-CODE.md
@@ -1,6 +1,6 @@
 # Installing Palinode with Claude Code
 
-Palinode gives Claude Code persistent memory via MCP — 18 tools for searching, saving, and managing memories across sessions. The `palinode-session` skill auto-captures milestones and decisions during coding, so your memory stays fresh without manual effort.
+Palinode gives Claude Code persistent memory via MCP — 17 tools for searching, saving, and managing memories across sessions. The `palinode-session` skill auto-captures milestones and decisions during coding, so your memory stays fresh without manual effort.
 
 ## Prerequisites
 
@@ -289,6 +289,7 @@ Search palinode for "recent project decisions"
 | `palinode_trigger` | Register a prospective recall trigger |
 | `palinode_lint` | Run health checks on memory files |
 | `palinode_session_end` | Capture session summary, decisions, blockers at end |
+| `palinode_prompt` | List, show, or activate versioned LLM prompts |
 
 ---
 


### PR DESCRIPTION
修复 docs/INSTALL-CLAUDE-CODE.md 中的工具数量错误：
- 描述从 '18 tools' 改为 '17 tools'（与 README 一致）
- 在工具列表末尾补充缺失的 palinode_prompt 条目

工具列表现在与 README.md 中的 17 个工具完全一致。