### PR TITLE
tests: replace os.system with subprocess.run for safer execution

### DIFF
--- a/tests/test_migrate_openclaw.py
+++ b/tests/test_migrate_openclaw.py
@@ -1,12 +1,13 @@
 """Tests for palinode.migration.openclaw — OpenClaw MEMORY.md import."""
 from __future__ import annotations
 
-import os
+import subprocess
 import textwrap
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import yaml as _yaml
 
 from palinode.migration.openclaw import (
     _detect_type,
@@ -48,12 +49,23 @@ def memory_md_file(tmp_path: Path) -> Path:
 
 @pytest.fixture()
 def fake_memory_dir(tmp_path: Path) -> Path:
+
     mem = tmp_path / "palinode"
     mem.mkdir()
+
     # Minimal git repo so the git commit call doesn't crash
-    os.system(f"git init -q {mem} 2>/dev/null")
-    os.system(f"git -C {mem} config user.email 'test@test.com' 2>/dev/null")
-    os.system(f"git -C {mem} config user.name 'Test' 2>/dev/null")
+    def run_git(args):
+        subprocess.run(
+            ["git"] + args,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True
+        )
+
+    run_git(["init","-q",str(mem)])
+    run_git(["-C",str(mem),"config","user.email","test@test.com"])
+    run_git(["-C", str(mem), "config", "user.name", "Test"])
+
     return mem
 
 
@@ -211,7 +223,6 @@ def test_migration_creates_log_file(
 def test_migration_frontmatter_fields(
     memory_md_file: Path, fake_memory_dir: Path
 ) -> None:
-    import yaml as _yaml
 
     with patch("palinode.migration.openclaw.config") as mock_cfg:
         mock_cfg.memory_dir = str(fake_memory_dir)


### PR DESCRIPTION
The test setup currently invokes git commands via os.system(),
which relies on shell interpretation and string formatting.

Replace these calls with subprocess.run() using explicit argument 
lists, avoiding shell usage and improving safety and portability.

Introduce a small helper (run_git) to reduce duplication in
git command invocation.

Additionally, inline import usage of yaml is normalized to a
module-level import.

The change is limited to test setup and preserves existing behavior.

No functional changes intended.