### PR TITLE
release: sync public main for v0.7.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,3 +108,26 @@ jobs:
       - name: Run pip-audit (dependency vulnerability check)
         run: pip-audit
         continue-on-error: true
+
+  # ---------------------------------------------------------------------------
+  # Shipping-leak scan — catch new SYNC-PUBLIC blacklist patterns at PR time.
+  #
+  # Failing here means the PR introduced a private reference (Tailscale IP,
+  # internal repo name, agent identifier, etc.) into a file that ships
+  # publicly. Fix at PR time rather than letting it propagate to staging.
+  #
+  # Runs only on PRs (not on pushes to main) and only against the diff
+  # vs the base branch — existing baseline leaks on dev main are not
+  # the concern of this check.
+  # ---------------------------------------------------------------------------
+  shipping-leak-scan:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0    # full history so the diff comparison works
+
+      - name: Scan PR diff for new shipping leaks
+        run: bash scripts/check-shipping-leaks.sh --diff "origin/${{ github.base_ref }}"

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,13 @@
 # PRIVATE DATA — never commit to public repo
 # ============================================================
 # These directories contain personal memories, session transcripts,
-# and private project data. They stay local only.
+# and private project data. They stay local only. The broad pattern
+# (no leading slash) is intentional: catches any nested `people/`,
+# `projects/`, etc., anywhere in the tree as defense-in-depth.
+#
+# Two legitimate code locations are exempted below:
+#   - palinode/      shipped code (e.g. palinode/migration/ module)
+#   - examples/      shipped sample-data demonstrating the format
 people/
 projects/
 decisions/
@@ -12,6 +18,9 @@ archive/
 inbox/
 migration/
 research/
+
+!palinode/**
+!examples/**
 
 # ============================================================
 # Derived / Operational
@@ -49,3 +58,6 @@ server.log
 nohup.out
 .engram.db
 .claude/worktrees/
+
+# Launch-posts working draft — local-only, not for git
+artifacts/launch-posts.md

--- a/PRD.md
+++ b/PRD.md
@@ -1,7 +1,7 @@
 ---
 created: 2026-03-22T16:02:00Z
 status: draft-v1
-author: Palinode contributors
+author: Paul Kyle + agent
 ---
 
 # Palinode — Product Requirements Document
@@ -52,7 +52,7 @@ All of these store things. None of them *remember*.
 
 **Primary:** AI agents (Claude-based) acting as long-lived personal assistants.
 
-**Secondary:** The human user who browses, edits, and reviews memory files directly; receives daily digests and weekly reviews.
+**Secondary:** The human (Paul) who browses, edits, and reviews memory files directly; receives daily digests and weekly reviews.
 
 **Tertiary:** Other AI agents that read from shared memory (multi-agent setups).
 
@@ -704,7 +704,7 @@ Prompts are not disposable. They're the most durable artifact in the system — 
 
 - [ ] Agent remembers project state across sessions without MEMORY.md
 - [ ] Semantic search returns relevant results for project/people queries
-- [ ] The user re-explains stable facts less often
+- [ ] Paul re-explains stable facts less often
 
 **After 1 month:**
 
@@ -717,4 +717,4 @@ Prompts are not disposable. They're the most durable artifact in the system — 
 
 - [ ] Multiple agents share Palinode (read access for all agent profiles)
 - [ ] Palinode has survived at least one infrastructure failure without data loss
-- [ ] The user trusts the system enough to stop manually curating MEMORY.md
+- [ ] Paul trusts the system enough to stop manually curating MEMORY.md

--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -63,7 +63,7 @@ Extract only things that will be useful **across sessions** — facts that a fut
 
 - *Example:* "Alice uses VS Code + Gemini 3.1 Pro (High) as default for executing milestone build specs." → Preference (tool + workflow).
 - *Example:* "Don't comment on time of day or suggest quitting." → Preference (communication). Already known — likely NOOP.
-- *NOT example:* the user opened vim once in a session → don't infer "prefers vim." Single instances aren't preferences.
+- *NOT example:* Paul used vim once in a session → don't infer "prefers vim." Single instances aren't preferences.
 
 **Technical context** — extract when it represents a *decision*, not just mentioned in passing.
 
@@ -120,7 +120,7 @@ id: person-{slug}
 category: person
 name: Full Name
 aliases: [nickname, shortened]
-role: their relationship to the user
+role: their relationship to Paul
 core: false  # set true for inner circle
 entities: [project/related-project]
 last_contact: 2026-03-22
@@ -129,7 +129,7 @@ last_updated: 2026-03-22T16:00:00Z
 # Full Name
 
 ## Context
-Who they are, how the user knows them, what their role is.
+Who they are, how Paul knows them, what their role is.
 
 ## Preferences & Communication
 How they like to work, communication style, things to remember.
@@ -275,7 +275,7 @@ last_updated: 2026-03-22T16:00:00Z
 - Bullet list of the important takeaways.
 
 ## Relevance
-Why this matters for the user's work.
+Why this matters for Paul's work.
 ```
 
 ---

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Paul Kyle",
     "url": "https://github.com/Paul-Kyle"
   },
-  "homepage": "https://github.com/phasespace-labs/palinode",
-  "repository": "https://github.com/phasespace-labs/palinode",
+  "homepage": "https://github.com/Paul-Kyle/palinode",
+  "repository": "https://github.com/Paul-Kyle/palinode",
   "license": "MIT",
   "keywords": [
     "memory",

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -85,7 +85,7 @@ systemctl --user enable --now palinode-api palinode-watcher
 Once Palinode is installed and the services are running, install this Claude Code plugin:
 
 ```
-/plugin install palinode@phasespace-labs
+/plugin install palinode@Paul-Kyle
 ```
 
 Or, during development, point Claude Code at this directory directly:
@@ -108,7 +108,7 @@ Once installed and connected, the plugin exposes 17 MCP tools to Claude Code:
 - `palinode_entities` — entity graph traversal (people, projects, decisions)
 
 ### Save and capture
-- `palinode_save` — write a new memory item. Supports type, entities, core flag, slug, source. As of v0.6.0, saves run write-time contradiction checking in the background.
+- `palinode_save` — write a new memory item. Supports type, entities, core flag, slug, source. As of v0.6.0, saves run write-time contradiction checking in the background (ADR-004).
 - `palinode_session_end` — capture session outcomes (summary, decisions, blockers) to daily notes and project status files
 - `palinode_ingest` — fetch a URL and store it as a research reference
 
@@ -163,6 +163,7 @@ Run `palinode_status` and check `total_files` and `fts_chunks`. If both are 0, t
 - [Main repository](https://github.com/phasespace-labs/palinode)
 - [CHANGELOG](https://github.com/phasespace-labs/palinode/blob/main/docs/CHANGELOG.md) for what's in v0.6.1
 - [Compaction demo](https://github.com/phasespace-labs/palinode/tree/main/examples/compaction-demo) — walkthrough of a memory file across three consolidation passes with blame + diff output
+- [ADR-001: Tools Over Pipeline](https://github.com/phasespace-labs/palinode/blob/main/ADR-001-tools-over-pipeline.md) — why the executor is deterministic
 
 ## License
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,17 +4,63 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ## Unreleased
 
+## [0.7.3] — 2026-04-26
+
 ### Added
+
+**Session-end semantic dedup (#126)**
+- `palinode_session_end` now checks recently indexed saves (default: last 60 minutes) for semantic overlap with the new content via cosine similarity on the existing BGE-M3 embeddings. When the best match scores at or above 0.85, the indexed individual file is skipped and the response carries `deduplicated_against: <slug>`. Daily-note and project-status appends are unchanged — only the duplicate indexed file is suppressed. Defaults `SESSION_END_DEDUP_WINDOW_MINUTES` and `SESSION_END_DEDUP_THRESHOLD` live in `palinode/core/defaults.py`. Embedder failures degrade gracefully: both files written, warning logged.
 
 **Search quality (M0.5)**
 - **Score-gap dedup** (#91, `52966ae`) — additional chunks from the same file are kept only if within `dedup_score_gap` (default 0.2) of the file's best score. Reduces noise from multi-section files dominating results.
-- **G1 context boost fix** (#92, `f156a3d`) — `store.search()` now accepts `context_entities` for ambient context boost. Previously the boost only fired through `search_hybrid`.
+- **G1 context boost fix** (#92, `f156a3d`) — `store.search()` now accepts `context_entities` for ADR-008 ambient context boost. Previously the boost only fired through `search_hybrid`.
 - **Raw cosine exposure** (#94, `ee8931a`) — search results include a `raw_score` field with the original cosine similarity before RRF normalization.
 - **Daily penalty** (#93, `d18240c`) — `daily/` files receive `score * daily_penalty` (default 0.3) to prevent daily notes from dominating search results. New `include_daily` parameter opts out of the penalty. Exposed as an MCP tool parameter.
 - **Canonical question frontmatter** (#83, `dbe5703`) — `canonical_question` frontmatter field (string or list) is prepended as `"Q: ..."` to the first chunk before embedding, anchoring each memory to the question it answers.
 
 **Tests**
 - 175 tests passing (up from 149)
+- **L1-L3 end-to-end test for `palinode session-end` (#139)** — `tests/integration/test_session_end_e2e_l1_l3.py` covers Tool fired / Data on disk / Retrievable layers of the four-layer validation model from `docs/VALIDATION-STRATEGY.md`. Drives the real CLI through `CliRunner` with the dual-write API call redirected into the in-process `TestClient`, manually triggers the watcher's per-file index path, and asserts a fresh client surfaces the record via `POST /search`. L4 (LLM-in-the-loop behavioural test) is deferred to `docs/L4-BEHAVIORAL-TESTING-DESIGN.md`.
+
+### Changed
+
+- **ADR-010 cross-surface monopoly is now total (#170)** — all CLI surfaces (`session-end`, `ingest`, `prompt`, `lint`, `list`) now route through `palinode/cli/_api.py`. The `GRANDFATHERED` list in `scripts/check-httpx-monopoly.sh` is now empty, and plugin parity tests were added on the TypeScript side. v0.7.3 ships with a single canonical API surface, eliminating silent feature drift between CLI and API.
+
+### Fixed
+
+- **Timestamp inconsistency in `chunks.created_at`** (#191) — two related bugs together made the column unreliable as a recency signal. `save_api` wrote `time.strftime("%Y-%m-%dT%H:%M:%SZ")` (local time formatted with a `Z` UTC suffix); switched to `_utc_now().isoformat()`. The watcher read `metadata.get("created", "")` while every producer writes the key as `created_at`; fixed the read. Existing rows still parse — values are just shifted by the local-vs-UTC offset until rewritten — so no migration is shipped. `palinode/core/store.py`'s file-mtime fallback (added in #183) remains as a defense for downstream consumers.
+- **Timestamp inconsistency in batch surfaces** (#193) — same Z-on-local-time hazard as #191/#192, this time on `last_updated` writes in four batch paths: `palinode/ingest/pipeline.py` (research files), `palinode/consolidation/layer_split.py` (identity / status / history), `palinode/migration/mem0_generate.py`, and `palinode/migration/openclaw.py`. All switched to `datetime.now(UTC).isoformat()` (or the existing `_utc_now().isoformat()` where the helper was already in scope). One incidental fifth surface — `palinode/consolidation/runner.py`'s `## Consolidation Log (...)` heading — was switched to a human-readable `... UTC` suffix to satisfy the project-wide `strftime("...Z")` audit (the audit now returns zero non-comment matches). `last_updated` isn't currently load-bearing for recency filters, so no migration is shipped.
+- **`.gitignore` no longer hides legitimate code paths** — the broad private-data rules (`people/`, `projects/`, `decisions/`, `insights/`, `migration/`, etc.) caught `palinode/migration/` and `examples/{people,projects,decisions,insights,sample-memory}/`, requiring `git add -f` for any new file under those paths. Added `!palinode/**` and `!examples/**` exemptions so the broad defense-in-depth pattern still catches accidental nested data anywhere else. As a consequence, four sample-memory files that the `examples/sample-memory/README.md` already advertised but were silently dropped on commit are now tracked: `decisions/api-design.md`, `people/alice.md`, `insights/testing.md`, `projects/my-app.md`. The sample tree now matches its README inventory (3 people, 1 project, 2 decisions, 1 insight).
+
+---
+
+## [0.7.2] — 2026-04-26
+
+Bug-fix release with small UX additions. Brings the public repo up to date with two production-impacting fixes (MCP array coercion, SessionEnd hook reasoning) plus search filters and structured session metadata. v0.8.0 remains reserved for Signed Provenance.
+
+### Added
+
+- **`/search` filters and recency-only mode (#141)** — `types: [...]` and `since_days: N` are now honored. Empty query routes to a recency-only path that orders by `created_at desc` with no semantic ranking. Backed by a new `store.list_recent()` that pushes type filtering into SQL via `json_extract`. Downstream consumers that wanted "recent Insights" or "recent Decisions from the last 14 days" can now do it in a single call.
+- **Structured `session_end` metadata (#145)** — `palinode_session_end` accepts `harness`, `cwd`, `model`, `trigger`, `session_id`, `duration_seconds`. Fields land in the daily-note text and the indexed file's frontmatter. If `project` is omitted but `cwd` is provided, the project slug auto-derives from the cwd's basename via the same slug rules `palinode init` uses.
+- **`palinode_save` `ps=true` shortcut (#136)** — MCP parity with the CLI `--ps` flag. `palinode_save` accepts either an explicit `type` or `ps=true` (shorthand for ProjectSnapshot). Conflict between `ps=true` and a non-ProjectSnapshot `type` errors clearly rather than silently ignoring one.
+- **Scope frontmatter parsing (#107)** — `scope`, `visibility`, `access` fields recognized in memory frontmatter. Parser-only in this release; search-time use lands in a follow-up.
+- **CLI banner** — `palinode --version` and `palinode banner` print the ASCII density-gradient mark.
+- **`docs/VALIDATION-STRATEGY.md` (#137)** — formalizes a four-layer model (Tool fired / Data on disk / Retrievable / Behavioral) for validating any cross-session feature, with PR-checklist template. Cross-linked from `docs/INSTALL-CLAUDE-CODE.md`.
+
+### Fixed
+
+- **MCP tolerates JSON-encoded array arguments (#147)** — some MCP transports double-encode array args as JSON strings. Previous behavior rejected with Pydantic 422 ("expected array, received string") on `palinode_session_end` and `palinode_save`, and silently corrupted the `paths` filter on `palinode_diff` (`",".join(string)` was joining char-by-char). New `_coerce_str_array` helper decodes JSON-array strings while passing native lists through unchanged.
+- **SessionEnd hook reason filter (#149)** — the hook's README claimed a `clear` matcher that never existed in `settings.json`. Replaced with explicit script-side filtering via a new `PALINODE_HOOK_REASONS` env var. Default allowlist: `clear logout prompt_input_exit other`. Override to narrow (e.g. `"clear"`) or extend (`+resume`, `+bypass_permissions_disabled`).
+- **Empty-transcript captures (#151)** — SessionEnd hook was capturing 0-message sessions despite `PALINODE_HOOK_MIN_MESSAGES=3`. Root cause: `grep -c '.'` on empty input emitted `"0"` and exited 1; the `|| echo "0"` fallback then appended another `"0"`, producing the literal three-byte string `"0\n0"` which made the integer test error and fall through. Fix: drop the `|| echo "0"` (grep always emits an integer regardless of exit), use `|| true` to absorb the non-zero, default to `0` if the pipeline produces nothing.
+- **Test isolation** — full-suite test runs no longer hit 5 failures in `test_write_time` due to scope-chain reload state pollution.
+
+### Documentation
+
+- **SSH keepalive options for remote-stdio MCP (`docs/MCP-SETUP.md`, `docs/INSTALL-CLAUDE-CODE.md`)** — `ServerAliveInterval=30`, `ServerAliveCountMax=3`, `TCPKeepAlive=yes` added to the example configs. Fixes the "MCP dies after laptop sleep / WiFi change" failure mode that hits anyone running palinode-api on a remote homelab box and SSH-spawning the MCP from a laptop. NAT and Tailscale's DERP relay drop idle TCP after a few minutes; without keepalives the IDE's MCP log fills with `Connection reset by peer`.
+
+### Tests
+
+- 325 tests passing on dev main (290 on the public-shipped subset; the 35 difference is reverted Phase-B actor-class and capabilities tests not part of this release).
 
 ---
 
@@ -31,7 +77,7 @@ First tagged release. Persistent memory for AI agents with git-versioned markdow
 - File watcher daemon with debounced reindex and fault isolation
 
 **Consolidation and compaction**
-- Deterministic executor applying `KEEP` / `UPDATE` / `MERGE` / `SUPERSEDE` / `ARCHIVE` operations proposed by an LLM
+- Deterministic executor applying `KEEP` / `UPDATE` / `MERGE` / `SUPERSEDE` / `ARCHIVE` operations proposed by an LLM (see [ADR-001](../ADR-001-tools-over-pipeline.md))
 - Weekly full-corpus consolidation with configurable LLM backend
 - Nightly lightweight consolidation pass (`--nightly` flag) bounded to `UPDATE`/`SUPERSEDE` for safer incremental updates
 - Model fallback chains — primary → fallback → fallback on timeout or HTTP error
@@ -63,6 +109,7 @@ First tagged release. Persistent memory for AI agents with git-versioned markdow
 - Exclude-paths list prevents search results from surfacing files in `.secrets`, `credentials`, etc.
 
 **Documentation**
+- [ADR-001: Tools Over Pipeline](../ADR-001-tools-over-pipeline.md) — why the executor is deterministic
 - Remote MCP setup guides for Claude Code, Claude Desktop, Cursor, Zed
 - Example memory files (`examples/people/`, `examples/projects/`, `examples/decisions/`, `examples/insights/`)
 - Compaction walkthrough (`examples/compaction-demo/`) — a memory file across 3 passes with blame + diff output

--- a/docs/HOW-MEMORY-WORKS.md
+++ b/docs/HOW-MEMORY-WORKS.md
@@ -289,7 +289,9 @@ Each chunk is hashed before embedding. If the hash matches the existing entry, t
 
 ## 6. Git Versioning (Every Change)
 
-Memories live in a git repository — typically a private repo you own, local or pushed to a remote of your choice. Every memory change is a git commit. This enables:
+**Repo:** `Paul-Kyle/palinode-data` (PRIVATE)
+
+Every memory change is a git commit. This enables:
 
 | Tool | What It Does | Example |
 | --- | --- | --- |

--- a/docs/L4-BEHAVIORAL-TESTING-DESIGN.md
+++ b/docs/L4-BEHAVIORAL-TESTING-DESIGN.md
@@ -1,0 +1,127 @@
+# L4 behavioural testing — design sketch
+
+**Status:** TBD — needs design discussion. Don't pick the architecture before
+the team has weighed the tradeoffs below.
+
+## What L4 is
+
+The fourth layer of the four-layer validation model in
+[`docs/VALIDATION-STRATEGY.md`](./VALIDATION-STRATEGY.md). L1-L3 are
+scriptable and ship in `tests/integration/test_session_end_e2e_l1_l3.py`
+(issue #139). L4 is the layer that asserts a *real LLM session*, given a
+fresh context, calls `palinode_search` on its own and surfaces the prior
+record in its response.
+
+L4 is the only layer that catches:
+
+- A perfectly indexed, perfectly retrievable record that no agent ever
+  surfaces because the CLAUDE.md session-start instructions are too vague.
+- A model that calls the wrong tool despite a deterministic prompt
+  (the `/wrap` and `/ps` slash commands rely on the model honouring
+  "always call X, never Y" — see ADR-010 and issue #140).
+- Search-query phrasing mismatches between what the agent forms and what
+  the indexer stored.
+
+## Why this needs a design discussion (not just an implementation ticket)
+
+Layer-4 tests are LLM-in-the-loop: they're slower than unit tests by orders
+of magnitude, they cost money or local-GPU time per run, and they're flaky
+in ways scripted tests aren't (sampling, prompt drift, model upgrades). The
+right architecture depends on cost tolerance, latency budget, and how often
+the team is willing to chase flakes — there is no neutral default. Pick
+deliberately.
+
+## Architectural option A — live LLM, per-PR
+
+Run the test against a real model (cloud Haiku, local Ollama, or Bedrock)
+on every PR that touches the L4-relevant surface area
+(`palinode_session_end`, `palinode_save`, `examples/hooks/`,
+`palinode/cli/init.py` `HOOK_SCRIPT`, slash command bodies, CLAUDE.md
+template content).
+
+**Tradeoffs**
+
+| | Pros | Cons |
+|---|---|---|
+| **Signal** | Catches regressions at PR time, before they ship. | Flaky — sampling and minor prompt drift can produce false reds; CI pollution from re-runs. |
+| **Cost** | Can use a cheap model (Haiku, gpt-4.1-mini, local Ollama qwen3-coder:30b) for a few cents per PR. | A dozen PRs/day × failed reruns = real money. Local Ollama is "free" but ties CI to a specific machine, breaks on shared runners. |
+| **Speed** | A single ~5s LLM call per layer is acceptable on a per-PR test. | Multiplied across the whole suite of cross-session features (`/wrap`, `/ps`, hook fallback, sessionresume, future ADRs), the budget compounds. |
+| **Determinism** | Temperature=0 + fixed seed reduces flakiness materially. | Model providers don't always honour seed across deploys; Anthropic doesn't expose seed at all. Provider-side updates can shift behaviour without notice. |
+
+## Architectural option B — recorded / snapshot replay, cron live
+
+Two-tier:
+
+1. **Per-PR (default):** replay a recorded LLM transcript. The test pins
+   an expected sequence of tool calls + arguments. Snapshots are checked
+   into the repo and re-recorded when prompts change (same pattern as
+   `pytest-recording` / VCR).
+2. **Cron (weekly or on-demand):** run the live-LLM version against
+   the latest model snapshot, fail loudly if behaviour drifts from the
+   recorded baseline.
+
+**Tradeoffs**
+
+| | Pros | Cons |
+|---|---|---|
+| **Signal** | Per-PR is fast and deterministic; cron catches drift before it sneaks in. | A snapshot can mask a regression if the snapshot was recorded against a model that was already wrong. Need a "snapshot review" step in PR review. |
+| **Cost** | Per-PR is free. Cron amortizes one live run across many merges. | Re-recording on prompt changes is manual toil; risk of stale snapshots. |
+| **Speed** | Snapshot replay is millisecond-fast. | Cron runs are still slow + expensive — but only once per cycle. |
+| **Determinism** | Replay is fully deterministic. | A snapshot validates "this prompt would have produced this trace against this model on this day," not "this prompt produces correct behaviour today." |
+
+## Cost considerations
+
+Concrete data points the team should sanity-check before picking option A:
+
+- **Cloud Haiku per call** (rough): ~3-4k input tokens (CLAUDE.md +
+  prompt + tool stubs) + ~500 output tokens per L4 test → ~$0.005/test.
+  Five L4 tests × 30 PRs/day = **~$0.75/day**, or ~$22/month. Acceptable
+  if reruns are bounded.
+- **Local Ollama (qwen3-coder:30b):** zero $-cost, ~5-10s/test on the
+  5060 VM, but means CI must reach that VM (Tailscale on shared CI is
+  not a default).
+- **Re-run amplification:** a 1-in-20 flake rate × an auto-retry policy
+  triples cost; rate-limit/lock to one retry max.
+- **Prompt-drift cost:** every change to `WRAP_COMMAND_BODY` /
+  `PS_COMMAND_BODY` / `CLAUDE_MD_BLOCK` re-records all snapshots in
+  option B. Budget for ~30s of dev time per such PR.
+
+## Open questions for the design discussion
+
+1. Does the team have a CI provider that can reach the local Ollama VM
+   over Tailscale? (Affects whether option A's "free local LLM" path is
+   available, or whether we're locked into cloud.)
+2. What's the acceptable false-red rate on a per-PR signal? <1% means
+   option B (snapshots) is the only path; ~5% is fine for option A with
+   a single retry.
+3. Should L4 block merge or post a soft signal? Soft signals are cheaper
+   to maintain but invite "the test is just flaky" dismissal.
+4. Where do the snapshots live if we go with option B? `tests/snapshots/`
+   would be a new top-level test dir — needs a scrub-list entry per the
+   public-repo policy.
+5. Is L4 one harness for all four `/wrap`-class flows (`/ps`, hook
+   fallback, etc.) or four separate tests with shared fixtures? One
+   harness scales; four tests catch tighter regressions.
+
+## Relationship to other work
+
+- **Issue #139** (this work) — covers L1-L3. L4 is the deferred remainder.
+- **Issue #140** — LLM-in-the-loop tests for the slash command prompts
+  themselves (assert that `/wrap` fires `palinode_session_end` and
+  `/ps` fires `palinode_save`, against a real model). Heavy overlap with
+  L4 of #139: a shared LLM-test harness would serve both. Probably the
+  right thing to design once and apply twice.
+- **`docs/VALIDATION-STRATEGY.md`** — the four-layer model. L4's
+  current status there is "Gap — see #42" (the now-renumbered #140).
+- **ADR-010** — the principle that `/wrap` and `/ps` are deterministic.
+  L4 is the test that validates the principle holds end-to-end against
+  a real model, not just at the prompt-text level.
+
+## Recommendation (not a decision)
+
+Lean toward **option B** (snapshots + cron) once the L4 harness is
+designed alongside #140. Per-PR live-LLM costs and flakiness compound
+faster than they look on a single feature; pinning a snapshot makes the
+expected behaviour explicit and reviewable, while cron catches model
+drift before it lands in user hands. But this is a recommendation, not
+a default — surface it with the team before building.

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -1,0 +1,71 @@
+# Palinode Roadmap
+
+The canonical roadmap lives in **GitHub milestones**. This document explains the milestone structure, themes, and order rationale so contributors can orient quickly.
+
+## Where to find the issues
+
+GitHub milestones page (filterable, links to all issues per milestone):
+
+- Browse open milestones in the repo's Issues tab → "Milestones"
+
+Each milestone groups related work toward a coherent outcome. The seven milestones together describe the path from current state to v1.0 and beyond.
+
+## The seven milestones
+
+### M1 — Distribution + Adoption
+
+Get Palinode in front of users across multiple IDEs. Smooth the install, make operational failures loud and recoverable, build the deploy story for self-hosters and the marketplace story for everyone else.
+
+Current focus: a `palinode doctor` command (umbrella for proactive misconfiguration detection), templated service deployment, MCP client config consistency, CI/CD discipline.
+
+### M2 — Agent Intelligence
+
+Sessions start smart, agents hand off cleanly, memory is scoped to the right audience. The largest milestone by issue count — covers cross-surface parity, integration tests, scope-chain layers, structured handoff tokens, and the auto-inject / dashboard / brief / tasks tools.
+
+### M3 — Memory Quality
+
+Improve what gets stored and how it evolves. Epistemic markers (fact vs inference vs open question), typed cross-links (supports/contradicts/refines), semantic contradiction detection, classification + smart prime, milestone dependency modeling. Smaller scope but high leverage on long-term store quality.
+
+### M4 — Import + Ecosystem
+
+Bring existing knowledge in. Generic markdown import, Obsidian integration (research stage — palinode is markdown-first by design, the substrate is already compatible), GitLab-aware entity linking, team scopes / agent-to-agent channels, OpenClaw profile migration.
+
+### M5 — Cloud + Colophon
+
+Team sharing, hosted deployment, provenance bridge. Cloud infrastructure with enforced RBAC, monorepo structure for a `palinode_cloud/` package, Ed25519 signed provenance receipts, Colophon Protocol integration. Currently paused pending IP-hygiene clearance; bridge plan captured separately.
+
+### M6 — v1.0 Packaging
+
+Homebrew, Nix, Mintlify docs site, package architecture restructure. Unblocked when M1 hardening is done — can't ship `brew install palinode` until silent-misconfiguration classes are caught proactively.
+
+### M7 — Research + Speculative
+
+Things worth thinking about that aren't yet committed: query-time delta compilation, prompt A/B testing, Cowork integration, multimodal embeddings (image/PDF), model step-change preparation, Palinode self-tracking, GrueBrain memory pathway rationalization.
+
+## Order rationale
+
+The order is intentional, not alphabetical:
+
+```
+M1 (foundation) → M2 (intelligence) → M3 (quality) → M4 (ecosystem) → M5/M6 (productization) → M7 (research)
+```
+
+- **M1 first.** Hardening blocks adoption. If silent-misconfiguration bites every new self-hosted user, no amount of feature work matters. Foundation precedes capability.
+- **M2 next.** The largest leverage point once foundation is solid is "make sessions actually smart" — handoff tokens, scope chains, parity contract enforcement.
+- **M3 third.** Memory quality builds on the agent-intelligence APIs (you need the surfaces before you refine what flows through them).
+- **M4 fourth.** Ecosystem integrations (Obsidian, GitLab, generic markdown import) work best on a stable, intelligent core. *Note: M4's research-stage items can begin in parallel with M1 — different code areas, different audiences, no conflict.*
+- **M5/M6 productization.** Cloud and packaging assume the underlying product is solid. Order between them is parallel-safe; M5 has external dependencies (Colophon clearance) that affect timing.
+- **M7 last.** Research items inform future direction but don't block shipping.
+
+## How to contribute
+
+- Browse the milestone you care about and look for `good first issue` labels
+- Bug reports and reproduction details are always welcome — file an issue with `bug` label
+- For larger proposals, open a discussion or draft an ADR before implementation
+- Each PR that touches public-shipping code should add a `CHANGELOG.md` entry under Unreleased
+
+## Related documents
+
+- `docs/CHANGELOG.md` — what shipped when
+- `ADR-001-tools-over-pipeline.md` and other ADRs in repo root — architectural decisions
+- `PROGRAM.md` — behavioral spec for memory extraction and consolidation

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -30,9 +30,9 @@ Improve what gets stored and how it evolves. Epistemic markers (fact vs inferenc
 
 Bring existing knowledge in. Generic markdown import, Obsidian integration (research stage — palinode is markdown-first by design, the substrate is already compatible), GitLab-aware entity linking, team scopes / agent-to-agent channels, OpenClaw profile migration.
 
-### M5 — Cloud + Colophon
+### M5 — Cloud + Signed Provenance
 
-Team sharing, hosted deployment, provenance bridge. Cloud infrastructure with enforced RBAC, monorepo structure for a `palinode_cloud/` package, Ed25519 signed provenance receipts, Colophon Protocol integration. Currently paused pending IP-hygiene clearance; bridge plan captured separately.
+Team sharing, hosted deployment, provenance bridge. Cloud infrastructure with enforced RBAC, monorepo structure for a `palinode_cloud/` package, and Ed25519 signed provenance receipts. This milestone is currently paused pending IP-hygiene clearance; the bridge plan is tracked separately.
 
 ### M6 — v1.0 Packaging
 
@@ -54,7 +54,7 @@ M1 (foundation) → M2 (intelligence) → M3 (quality) → M4 (ecosystem) → M5
 - **M2 next.** The largest leverage point once foundation is solid is "make sessions actually smart" — handoff tokens, scope chains, parity contract enforcement.
 - **M3 third.** Memory quality builds on the agent-intelligence APIs (you need the surfaces before you refine what flows through them).
 - **M4 fourth.** Ecosystem integrations (Obsidian, GitLab, generic markdown import) work best on a stable, intelligent core. *Note: M4's research-stage items can begin in parallel with M1 — different code areas, different audiences, no conflict.*
-- **M5/M6 productization.** Cloud and packaging assume the underlying product is solid. Order between them is parallel-safe; M5 has external dependencies (Colophon clearance) that affect timing.
+- **M5/M6 productization.** Cloud and packaging assume the underlying product is solid. Order between them is parallel-safe; M5 has external dependencies around signed-provenance clearance that affect timing.
 - **M7 last.** Research items inform future direction but don't block shipping.
 
 ## How to contribute

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -1,0 +1,162 @@
+# PARITY.md — Cross-Surface Contract
+
+**Status:** Active (ADR-010 accepted 2026-04-26)
+**Source of truth:** `palinode/core/parity.py` — the registry
+**Forcing function:** `tests/test_surface_parity.py` — CI-blocking
+**Defaults:** `palinode/core/defaults.py` — single-place values for thresholds, cooldowns, source headers
+
+## The contract
+
+Every memory operation that appears on more than one surface must use **the same canonical parameter names with the same shapes**. The four surfaces are:
+
+1. **CLI** — `palinode <command>`
+2. **MCP** — `palinode_<tool>` (Claude Code, Cursor, IDEs)
+3. **REST API** — `POST/GET /<endpoint>`
+4. **OpenClaw plugin** — `palinode_<tool>` (TypeScript)
+
+When you add a parameter, add it to all four surfaces (modulo exemptions below) and to `parity.py`. CI fails otherwise.
+
+## Adding or changing a parameter
+
+1. Add the `CanonicalParam` to the relevant `Operation` in `palinode/core/parity.py`.
+2. If the parameter has a default that's shared across surfaces, add it to `palinode/core/defaults.py` and reference via `default_key`.
+3. Implement on every required surface (see the Operation's `required_surfaces`).
+4. Run `pytest tests/test_surface_parity.py`. If a surface is intentionally lagging — say, a CLI implementation will land in a follow-up PR — record it as `known_drift[("cli", "name")] = <issue_number>`. The test then xfails with the issue ref instead of failing.
+5. Open the GitHub issue, link to the canonical param, and assign the missing surface to a follow-up.
+
+When the surface is fixed, **remove the `known_drift` entry**. The parity test fails loudly if drift was tracked and the param now exists — that's the test telling you to close the issue.
+
+## Admin-exempt operations
+
+These operations are **not** required to appear on every surface. They are intentionally CLI-only or CLI+API only because they're operational, not memory-semantic.
+
+| Operation              | Surfaces                | Reason                              |
+|------------------------|-------------------------|-------------------------------------|
+| `reindex`              | CLI + API               | Full database rescan                |
+| `rebuild-fts`          | CLI + API               | FTS5 index rebuild                  |
+| `split-layers`         | CLI + API               | One-shot core-layer migration       |
+| `bootstrap-fact-ids`   | CLI + API               | Backfill fact IDs                   |
+| `migrate-openclaw`     | CLI + API               | One-off importer                    |
+| `migrate-mem0`         | CLI + API               | One-off importer                    |
+| `doctor`               | CLI                     | Local diagnostics                   |
+| `start`, `stop`        | CLI                     | systemd unit control                |
+| `config`, `banner`     | CLI                     | Local UI                            |
+| `health`, `git-stats`  | API                     | Observability internals             |
+| `generate-summaries`   | API                     | Internal LLM workflow               |
+
+The list is canonical at `palinode.core.parity.ADMIN_EXEMPT_OPERATIONS`. Adding a new admin operation requires updating the table here and that constant. Adding a new memory operation does **not** put it on this list — memory operations are subject to parity by default.
+
+## Canonical names — the high-friction list
+
+These are the spellings the registry agreed on. Forbidden aliases are flagged in PR review (and grepped by `scripts/check-httpx-monopoly.sh` for one specific class — see below).
+
+| Concept                         | Canonical            | Forbidden aliases                       |
+|---------------------------------|----------------------|-----------------------------------------|
+| Path to a memory file           | `file_path`          | `file`, `path`, `filename`              |
+| Memory category (directory)     | `category` (plural)  | `category` (singular), `dir`            |
+| Project association             | `project` (string)   | `project_slug`, `entity` prefix only    |
+| Entity refs                     | `entities` (list)    | `entity` (single), `tags`               |
+| Memory type (closed enum)       | `type`               | `kind`, `category`                      |
+| ProjectSnapshot shortcut        | `ps` (boolean)       | `is_ps`, `snapshot`                     |
+| Dry-run preview flag            | `dry_run`            | `--execute` (negation), `preview`       |
+| Source-surface attribution      | `X-Palinode-Source` header (preferred) or `source` field | per-surface `source` literals |
+
+### Categories — exact set
+
+Memory categories match directory names (plural), per `palinode/api/server.py:660-668`:
+
+```
+people, projects, decisions, insights, research
+```
+
+Singular variants (`person`, `project`, etc.) are **entity-ref prefixes**, not category values — see `_CATEGORY_TO_ENTITY_PREFIX` in `server.py:180-187`.
+
+### Memory types — exact set
+
+```
+PersonMemory, Decision, ProjectSnapshot, Insight, ResearchRef, ActionItem
+```
+
+Stored at `palinode/core/parity.py:MEMORY_TYPES`. The plugin's `palinode_save` schema declares `type` (it accepts the enum values as a free-form string today; tightening to a TypeBox `Union` of literal types is the remaining slice of #166).
+
+### Prompt tasks — exact set
+
+```
+compaction, extraction, update, classification, nightly-consolidation
+```
+
+Stored at `palinode/core/parity.py:PROMPT_TASKS`. ADR-010 #162 fixed the duplicate-`enum` bug at `palinode/mcp.py:624-625`; the canonical list now lives in `parity.py`.
+
+## Surface sugar — opt-in convenience, not parity
+
+A few parameters are surface-specific by design — they exist to make a surface ergonomic without changing the underlying API contract. These are **not** in the canonical params list. The plugin and other surfaces are free to add them or skip them; the parity test does not enforce.
+
+- **`save --ps` / MCP `ps`** — shorthand for `type=ProjectSnapshot`. Resolved locally before the API call. The CLI and MCP have it; the API and plugin do not need it.
+- **CLI `save --file <path>`** — read content from a file rather than passing inline. Local convenience; the API takes content directly.
+
+If a surface adds sugar, document it here.
+
+## How the test reads parity
+
+`tests/test_surface_parity.py` walks `REGISTRY` and for each `(operation, surface, canonical_param)` tuple:
+
+1. **Exempt surface?** Skipped (per `Operation.exempt_surfaces`).
+2. **Plugin?** Skipped on the Python side (Python can't introspect the TypeBox schemas). The TS-side test at `plugin/test/parity.test.ts` enforces plugin parity using the JSON dump produced by `scripts/dump-parity-registry.py`. Run with `cd plugin && npm test`.
+3. **In `known_drift`?** xfailed with `reason="drift tracked in #<issue>"`. The test passes; the issue tracks the fix.
+4. **Otherwise:** asserted present. Missing → CI red.
+
+The test additionally enforces:
+
+- `test_admin_exempt_ops_are_not_in_registry` — the two lists are disjoint.
+- `test_default_keys_resolve` — every `default_key` reference in the registry exists in `palinode/core/defaults.py`.
+- `test_known_drift_references_a_canonical_param` — `known_drift` keys must reference real canonical param names (catches dangling drift entries after a refactor).
+
+## httpx monopoly — the bypass linter
+
+CLI commands and the plugin go through one HTTP layer each: `palinode/cli/_api.py` and `palinode/mcp.py`. Direct `httpx` calls from elsewhere skip rate limiting, audit logging, source headers, and any future API-side fixes. The pre-commit linter at `scripts/check-httpx-monopoly.sh` greps for offenders and fails CI.
+
+Today's bypass-vector files (cleanup tracked in #168 and #170 lower-tier):
+
+- `palinode/cli/read.py` — reads disk directly, never calls API
+- `palinode/cli/list.py` — uses raw `httpx.get`
+- `palinode/cli/lint.py` — falls back to direct module import on connection failure
+- `palinode/cli/session_end.py` — bypasses `_api.py`
+
+After cleanup, the linter prevents recurrence.
+
+## Known drift — at-a-glance
+
+The registry is the precise list. This summary tracks roll-up status:
+
+| Issue | Operation | Surfaces | Param           | Status |
+|-------|-----------|----------|-----------------|--------|
+| #159  | save      | CLI/MCP/API/Plugin | project | open |
+| #161  | search    | MCP      | category enum (singular→plural) | **fixed in this commit** |
+| #162  | prompt    | MCP      | duplicate `enum` keys           | **fixed in this commit** |
+| #163  | search    | CLI      | since_days, types, threshold, date_after, date_before, include_daily | open |
+| #163  | search    | MCP      | since_days, types, threshold | open |
+| #163  | search    | Plugin   | threshold, since_days, types, date_after, date_before, include_daily | open |
+| #164  | rollback  | MCP      | file_path (canonical name)      | open |
+| #164  | rollback  | CLI      | dry_run (--execute negation)    | open |
+| #164  | blame     | MCP      | file_path (canonical name)      | open |
+| #165  | trigger.create | CLI | cooldown_hours, trigger_id     | open |
+| #165  | trigger.create | MCP | threshold, cooldown_hours      | open |
+| #166  | save      | CLI/MCP  | metadata, confidence            | open |
+| #166  | save      | CLI      | slug, core                      | open |
+| #166  | save      | MCP/API  | title                           | open |
+| #166  | save      | Plugin   | metadata, confidence, project, title, source | open |
+| #168  | read      | MCP      | meta (frontmatter passthrough)  | open |
+| #169  | consolidate | MCP    | dry_run, nightly                | open |
+
+When an issue closes:
+1. Remove its entry from `Operation.known_drift` in `palinode/core/parity.py`.
+2. Update the row in this table.
+3. Run the parity test — should go from xfail to pass for the affected case.
+
+## See also
+
+- `ADR-010-cross-surface-parity-contract.md` — the decision and rationale.
+- `palinode/core/parity.py` — the registry (source of truth).
+- `palinode/core/defaults.py` — shared defaults.
+- `tests/test_surface_parity.py` — the forcing function.
+- Issue #170 — implementation tracking.

--- a/docs/VALIDATION-STRATEGY.md
+++ b/docs/VALIDATION-STRATEGY.md
@@ -66,12 +66,12 @@ Skipping a layer is a yellow flag. Skipping L4 because "it's hard to automate" i
 
 | Layer | Status | Where |
 |---|---|---|
-| L1 | Partial | Existing pytest suite covers tool exit codes via `tests/test_session_end.py` and `tests/test_cli_init.py` |
-| L2 | Partial | Same tests assert frontmatter shape and file existence |
-| L3 | **Gap** — see [#41](https://github.com/phasespace-labs/palinode/issues/41) | Integration test for end-to-end `/wrap` → `/clear` → recall is on the roadmap |
-| L4 | **Gap** — see [#42](https://github.com/phasespace-labs/palinode/issues/42) | Automated LLM-in-the-loop test is on the roadmap |
+| L1 | Covered | `tests/test_session_end.py`, `tests/test_cli_init.py`, and the L1 case in `tests/integration/test_session_end_e2e_l1_l3.py` |
+| L2 | Covered | Same suites — frontmatter shape, file existence, daily-note + project-status content |
+| L3 | Covered | `tests/integration/test_session_end_e2e_l1_l3.py` — fresh `TestClient` issues `POST /search` against the on-disk SQLite DB written by the CLI's dual-write |
+| L4 | **Gap** — see [`docs/L4-BEHAVIORAL-TESTING-DESIGN.md`](./L4-BEHAVIORAL-TESTING-DESIGN.md) and [#42](https://github.com/phasespace-labs/palinode/issues/42) | Automated LLM-in-the-loop test design is sketched but not yet implemented |
 
-Until #41 and #42 land, L3 and L4 are manual on every cross-session-feature PR. Document the manual evidence in the PR; don't assume future you will remember what you ran.
+Until L4 lands, L4 is manual on every cross-session-feature PR. Document the manual evidence in the PR; don't assume future you will remember what you ran.
 
 ## Related
 

--- a/examples/compaction-demo/README.md
+++ b/examples/compaction-demo/README.md
@@ -41,7 +41,7 @@ Between pass 1 and pass 2 (9 operations):
 - 4 × `ARCHIVE` — moved superseded entries to `archive/2026/my-app-status.md`
 - 2 × `UPDATE` — final wording pass on merged lines
 
-All 22 operations were **proposed by an LLM** but **applied by deterministic Python** (`palinode/consolidation/executor.py`). The LLM never touches the file directly — it only emits JSON like `{"op": "SUPERSEDE", "id": "f-0317-1", "superseded_by": "f-0324-2", "reason": "stripe integration actually shipped on the 24th"}` and the executor validates and applies it.
+All 22 operations were **proposed by an LLM** but **applied by deterministic Python** (`palinode/consolidation/executor.py`). The LLM never touches the file directly — it only emits JSON like `{"op": "SUPERSEDE", "id": "f-0317-1", "superseded_by": "f-0324-2", "reason": "stripe integration actually shipped on the 24th"}` and the executor validates and applies it. That's the [ADR-001](../../ADR-001-tools-over-pipeline.md) invariant in action.
 
 ## Why this matters
 

--- a/examples/sample-memory/decisions/api-design.md
+++ b/examples/sample-memory/decisions/api-design.md
@@ -1,0 +1,30 @@
+---
+id: decision-api-design
+category: decision
+core: false
+entities: [project/my-app]
+last_updated: 2026-03-31
+summary: "Decided on REST over GraphQL for the checkout API — simpler caching, team expertise, Stripe webhooks are REST-native."
+---
+# Decision: REST API for Checkout
+
+## What Was Decided
+Use REST endpoints for the checkout API instead of GraphQL.
+
+## Why
+- Team has 3 years of REST experience, 0 with GraphQL
+- Stripe webhooks are REST-native — no translation layer needed
+- CDN/edge caching is straightforward with REST (cache by URL)
+- Checkout flow has predictable data shapes — GraphQL flexibility isn't needed
+
+## What We Considered
+- **GraphQL**: flexible queries, single endpoint, but steeper learning curve and no caching story for mutations
+- **tRPC**: type-safe, but too coupled to TypeScript — we may need Python services later
+
+## Trade-offs Accepted
+- Multiple endpoints to maintain (vs single GraphQL endpoint)
+- Over-fetching on some routes (acceptable for checkout — small payloads)
+- If we add a mobile-specific BFF later, GraphQL might make more sense
+
+## Date
+2026-03-15 — decided in architecture review with Alice and Bob.

--- a/examples/sample-memory/decisions/single-page-checkout.md
+++ b/examples/sample-memory/decisions/single-page-checkout.md
@@ -1,0 +1,24 @@
+---
+id: decision-single-page-checkout
+category: decision
+core: false
+entities: [project/my-app, person/alice]
+last_updated: 2026-03-20
+summary: "Single-page checkout over multi-step wizard. A/B test showed 23% higher completion rate."
+---
+# Decision: Single-Page Checkout
+
+## What Was Decided
+Use a single-page checkout flow instead of a multi-step wizard.
+
+## Why
+- A/B test on staging showed 23% higher completion rate with single-page
+- Fewer page loads = faster on mobile networks
+- Easier to implement error recovery (no state to lose between steps)
+
+## Trade-offs Accepted
+- Longer initial page load (more components up front)
+- Address validation and payment fields visible together (could feel cluttered on small screens)
+
+## Date
+2026-03-20 — decided after reviewing A/B test results with Alice.

--- a/examples/sample-memory/insights/testing.md
+++ b/examples/sample-memory/insights/testing.md
@@ -1,0 +1,29 @@
+---
+id: insight-testing-strategy
+category: insight
+core: false
+entities: [project/my-app]
+last_updated: 2026-03-31
+summary: "Integration tests catch more real bugs than unit tests for API-heavy apps. Write fewer, broader tests."
+---
+# Insight: Integration Tests > Unit Tests for API Work
+
+## The Lesson
+For API-heavy applications (like our checkout flow), integration tests that hit real endpoints catch significantly more production-relevant bugs than isolated unit tests.
+
+## Evidence
+- 3 critical bugs in the Stripe integration were caught by integration tests, 0 by unit tests
+- The bugs were all at the boundary: request serialization, webhook signature verification, idempotency key handling
+- Unit tests with mocked HTTP calls passed fine — the mocks were wrong
+
+## The Principle
+When your app is mostly glue between services, test the glue, not the pieces. Write fewer tests that cover more surface area.
+
+## When This Applies
+- Payment integrations (API boundaries)
+- Multi-service architectures (service-to-service contracts)
+- Webhook handlers (real HTTP matters)
+
+## When It Doesn't Apply
+- Pure computation (math, parsing, algorithms) — unit tests are better
+- UI components — snapshot/visual tests are better

--- a/examples/sample-memory/people/alice.md
+++ b/examples/sample-memory/people/alice.md
@@ -1,0 +1,28 @@
+---
+id: person-alice
+category: person
+name: Alice Chen
+core: true
+entities: [project/my-app]
+last_updated: 2026-03-31
+summary: "Alice Chen — product lead at Acme Corp. Working on the mobile checkout redesign. Prefers async communication."
+---
+# Alice Chen
+
+## Context
+Product lead at Acme Corp. Working on the mobile checkout redesign with Bob. Reports to the VP of Product.
+
+## Communication
+- Prefers async (Slack/email over meetings)
+- Timezone: US/Eastern
+- Best time to reach: mornings before standup
+
+## Preferences
+- Values data-driven decisions — bring numbers, not opinions
+- Likes short docs with clear recommendations
+- Dislikes: scope creep without explicit tradeoff discussion
+
+## Current Focus
+- Mobile checkout conversion rate optimization
+- Q2 launch deadline: April 15
+- Blocked on: payment provider API integration (waiting on Bob)

--- a/examples/sample-memory/people/bob.md
+++ b/examples/sample-memory/people/bob.md
@@ -1,0 +1,23 @@
+---
+id: person-bob
+category: person
+name: Bob Martinez
+core: false
+entities: [project/my-app]
+last_updated: 2026-03-31
+summary: "Bob Martinez — backend engineer at Acme Corp. Owns the Stripe integration for the checkout redesign."
+---
+# Bob Martinez
+
+## Context
+Backend engineer at Acme Corp. 4 years at the company, deep knowledge of the legacy payment system.
+
+## Current Focus
+- Stripe SDK integration for the checkout redesign
+- Migrating webhook handlers from PayPal to Stripe
+- On track for April 1 completion
+
+## Technical Notes
+- Prefers TypeScript strict mode, no `any` types
+- Strong opinions on error handling — always use typed error unions
+- Maintains the internal API client library

--- a/examples/sample-memory/people/carol.md
+++ b/examples/sample-memory/people/carol.md
@@ -1,0 +1,22 @@
+---
+id: person-carol
+category: person
+name: Carol Wu
+core: false
+entities: [project/my-app]
+last_updated: 2026-04-01
+summary: "Carol Wu — QA lead at Acme Corp. Owns the test plan for the checkout redesign launch."
+---
+# Carol Wu
+
+## Context
+QA lead at Acme Corp. Responsible for the test plan and sign-off before the April 15 launch.
+
+## Current Focus
+- Writing end-to-end test scenarios for the new checkout flow
+- Coordinating with Bob on Stripe sandbox test credentials
+- Regression testing the legacy cart integration
+
+## Notes
+- Prefers detailed test plans in Google Sheets
+- Flags issues via Linear, tagged with `checkout-qa`

--- a/examples/sample-memory/projects/my-app.md
+++ b/examples/sample-memory/projects/my-app.md
@@ -1,0 +1,39 @@
+---
+id: project-my-app
+category: project
+name: Mobile Checkout Redesign
+status: active
+core: true
+entities: [person/alice, person/bob]
+last_updated: 2026-03-31
+summary: "Mobile checkout redesign for Acme Corp. React Native + Stripe. Q2 launch target April 15. Currently in integration testing."
+---
+# Mobile Checkout Redesign
+
+## What This Is
+Complete redesign of the mobile checkout flow for Acme Corp's e-commerce app. Goal: increase conversion rate from 2.1% to 3.5%.
+
+## Architecture
+- Frontend: React Native (Expo)
+- Payment: Stripe SDK (replacing legacy PayPal integration)
+- Backend: Node.js API on Render
+- Database: Postgres + Prisma ORM
+
+## Status
+Integration testing phase. Core checkout flow works. Payment provider API integration in progress (Bob's track).
+
+## Milestones
+- [x] Design review complete (March 1)
+- [x] Core UI components built (March 15)
+- [ ] Stripe integration complete (target: April 1)
+- [ ] QA pass (target: April 8)
+- [ ] Launch (target: April 15)
+
+## Key Decisions
+- Chose Stripe over Square — better React Native SDK, lower per-transaction fees
+- Single-page checkout (not multi-step) — A/B test showed 23% higher completion
+- Guest checkout enabled by default — reduces friction for first-time buyers
+
+## Open Questions
+- [ ] Do we need Apple Pay / Google Pay for launch or can it wait?
+- [ ] Error handling UX for declined cards — show inline or modal?

--- a/palinode/__init__.py
+++ b/palinode/__init__.py
@@ -11,4 +11,9 @@ Components:
     mcp.py      — MCP server for Claude Code integration
     cli.py      — Command-line interface
 """
-__version__ = "0.7.0"
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+try:
+    __version__ = _pkg_version("palinode")
+except PackageNotFoundError:  # pragma: no cover — only when running from a non-installed checkout
+    __version__ = "0.0.0+unknown"

--- a/palinode/api/server.py
+++ b/palinode/api/server.py
@@ -29,6 +29,12 @@ from pydantic import BaseModel
 
 from palinode.core import store, embedder, git_tools
 from palinode.core.config import config
+from palinode.core.defaults import (
+    SAVE_SOURCE_API_DEFAULT,
+    SAVE_SOURCE_HEADER,
+    SESSION_END_DEDUP_THRESHOLD,
+    SESSION_END_DEDUP_WINDOW_MINUTES,
+)
 
 
 logger = logging.getLogger("palinode.api")
@@ -67,7 +73,7 @@ async def lifespan(app: FastAPI):
     """Initialize database and background workers on startup."""
     store.init_db()
 
-    # Tier 2a: write-time contradiction check worker
+    # Tier 2a (ADR-004): write-time contradiction check worker
     if config.consolidation.write_time.enabled:
         try:
             from palinode.consolidation import write_time
@@ -205,6 +211,28 @@ def _normalize_entities(entities: list[str], category: str) -> list[str]:
     return normalized
 
 
+def _resolve_source(req_source: str | None, request: "Request | None") -> str:
+    """Resolve the source-surface attribution for a write.
+
+    Precedence (ADR-010 / #167):
+      1. Explicit ``source`` field in the request body — caller's intent wins.
+      2. ``X-Palinode-Source`` HTTP header — set automatically by CLI/MCP.
+      3. ``PALINODE_SOURCE`` environment variable — operator override.
+      4. ``"api"`` default — used when nothing above is set.
+    """
+    if req_source:
+        return req_source
+    if request is not None:
+        # FastAPI normalizes header names to lowercase on read; supply both
+        # spellings to be safe across stacks.
+        hdr = request.headers.get(SAVE_SOURCE_HEADER) or request.headers.get(
+            SAVE_SOURCE_HEADER.lower()
+        )
+        if hdr:
+            return hdr
+    return os.environ.get("PALINODE_SOURCE", SAVE_SOURCE_API_DEFAULT)
+
+
 def _generate_description(content: str) -> str:
     """Generate a one-line description for a memory file.
 
@@ -323,7 +351,7 @@ class SearchRequest(BaseModel):
     hybrid: bool | None = None
     date_after: str | None = None
     date_before: str | None = None
-    context: list[str] | None = None  # Entity refs for ambient context boost
+    context: list[str] | None = None  # Entity refs for ambient context boost (ADR-008)
     include_daily: bool | None = False  # Skip daily/ penalty when True (#93)
     # #141: filter by memory `type` frontmatter (one of PersonMemory, Decision,
     # ProjectSnapshot, Insight, ResearchRef, ActionItem). Independent of `category`
@@ -360,6 +388,14 @@ class SaveRequest(BaseModel):
     core: bool | None = None
     source: str | None = None
     confidence: float | None = None
+    #: Optional human-readable title.  When set, it's stored in frontmatter
+    #: and used for display in lists/search results.  ADR-010 / #166.
+    title: str | None = None
+    #: Sugar: ``project="foo"`` is equivalent to appending ``"project/foo"``
+    #: to ``entities``.  ADR-010 / #159.  If both are given and there's a
+    #: mismatch, both values land — same as supplying ``entities=["project/a",
+    #: "project/b"]`` directly.
+    project: str | None = None
 
 
 @app.get("/list")
@@ -500,7 +536,7 @@ def search_api(req: SearchRequest, request: Request = None) -> list[dict[str, An
         effective_date_after = _compute_effective_date_after(req)
         limit = req.limit or config.search.default_limit
 
-        # Empty query → recency-only mode. Skip embedding, query chunks
+        # #141: empty query → recency-only mode. Skip embedding, query chunks
         # directly ordered by created_at desc, apply types/date_after filter.
         if not req.query.strip():
             return store.list_recent(
@@ -511,7 +547,7 @@ def search_api(req: SearchRequest, request: Request = None) -> list[dict[str, An
                 limit=limit,
             )
 
-        # Augment query with project context before embedding
+        # ADR-008: Augment query with project context before embedding
         embed_query = req.query
         if req.context and config.context.enabled and config.context.embed_augment:
             # Extract project name from entity ref (e.g., "project/palinode" → "palinode")
@@ -636,7 +672,7 @@ def save_api(req: SaveRequest, request: Request = None, sync: bool = False) -> d
     """Persists a new memory instance chunk locally and initiates git backup sequences.
 
     Query params:
-        sync: If True, runs the write-time contradiction check (tier 2a)
+        sync: If True, runs the write-time contradiction check (tier 2a, ADR-004)
               inline and returns its result. If False (default), the check is
               enqueued for background processing and the response returns as
               soon as the file is written and git-committed.
@@ -679,7 +715,12 @@ def save_api(req: SaveRequest, request: Request = None, sync: bool = False) -> d
 
     # Normalize entity refs: bare strings get a category prefix.
     # e.g. "palinode" → "project/palinode", "alice" → "person/alice"
-    raw_entities = req.entities or []
+    raw_entities = list(req.entities or [])
+    # ADR-010 / #159: ``project`` is sugar for the ``project/<slug>`` entity.
+    if req.project:
+        project_ref = req.project if "/" in req.project else f"project/{req.project}"
+        if project_ref not in raw_entities:
+            raw_entities.append(project_ref)
     normalized_entities = _normalize_entities(raw_entities, category)
 
     frontmatter_dict = {
@@ -688,7 +729,11 @@ def save_api(req: SaveRequest, request: Request = None, sync: bool = False) -> d
         "type": req.type,
         "entities": normalized_entities,
         "content_hash": content_hash,
-        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ")
+        # #191: write proper timezone-aware UTC ISO-8601 (`+00:00` suffix).
+        # Previously used ``time.strftime("...%Z")`` which emitted local time
+        # with a ``Z`` (UTC) marker — a mismatch that made `chunks.created_at`
+        # unreliable as a recency signal.
+        "created_at": _utc_now().isoformat()
     }
     if req.metadata:
         frontmatter_dict.update(req.metadata)
@@ -696,8 +741,12 @@ def save_api(req: SaveRequest, request: Request = None, sync: bool = False) -> d
         frontmatter_dict["core"] = req.core
     if req.confidence is not None:
         frontmatter_dict["confidence"] = req.confidence
+    # ADR-010 / #166: explicit ``title`` overrides metadata-supplied title.
+    if req.title:
+        frontmatter_dict["title"] = req.title
 
-    frontmatter_dict["source"] = req.source or os.environ.get("PALINODE_SOURCE", "api")
+    # ADR-010 / #167: explicit body field > X-Palinode-Source header > env > "api".
+    frontmatter_dict["source"] = _resolve_source(req.source, request)
 
     # Auto-generate description if not already provided via metadata
     if not frontmatter_dict.get("description"):
@@ -742,7 +791,7 @@ def save_api(req: SaveRequest, request: Request = None, sync: bool = False) -> d
 
     result: dict[str, Any] = {"file_path": file_path, "id": frontmatter_dict["id"]}
 
-    # Tier 2a: schedule write-time contradiction check.
+    # Tier 2a (ADR-004): schedule write-time contradiction check.
     # Always safe to call — returns None immediately if disabled in config.
     # Errors inside the scheduler are logged and swallowed; never propagate.
     if config.consolidation.write_time.enabled:
@@ -842,7 +891,7 @@ def status_api() -> dict[str, Any]:
         
     stats["ollama_reachable"] = ollama_reachable
 
-    # Tier 2a observability
+    # Tier 2a (ADR-004) observability
     stats["write_time_enabled"] = config.consolidation.write_time.enabled
     if config.consolidation.write_time.enabled:
         try:
@@ -1187,6 +1236,67 @@ class SessionEndRequest(BaseModel):
     duration_seconds: int | None = None
 
 
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Cosine similarity between two equally-sized vectors.
+
+    Returns 0.0 on shape mismatch or zero-magnitude inputs so the caller
+    can treat "incomparable" the same as "not similar enough."
+    """
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    import math
+    return dot / (math.sqrt(na) * math.sqrt(nb))
+
+
+def _check_session_end_dedup(
+    content: str,
+    window_minutes: int = SESSION_END_DEDUP_WINDOW_MINUTES,
+    threshold: float = SESSION_END_DEDUP_THRESHOLD,
+) -> tuple[str | None, float]:
+    """Look for a recent indexed save whose embedding is near-identical to ``content`` (#126).
+
+    Returns ``(matched_slug, similarity)`` when a recent save scores at or
+    above ``threshold``; ``(None, 0.0)`` otherwise.  Failure modes — empty
+    embedding from the embedder, no recent saves, or DB error inside the
+    helper — return ``(None, 0.0)`` so the caller writes both files.
+    """
+    try:
+        new_emb = embedder.embed(content)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"session_end dedup: embed failed ({e}); writing without dedup")
+        return None, 0.0
+    if not new_emb:
+        logger.warning("session_end dedup: embedder returned empty vector; writing without dedup")
+        return None, 0.0
+
+    try:
+        recent = store.recent_save_embeddings(window_minutes)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(f"session_end dedup: recent_save_embeddings failed ({e}); writing without dedup")
+        return None, 0.0
+
+    best_slug: str | None = None
+    best_sim = 0.0
+    for slug, emb in recent:
+        sim = _cosine_similarity(new_emb, emb)
+        if sim > best_sim:
+            best_sim = sim
+            best_slug = slug
+
+    if best_slug is not None and best_sim >= threshold:
+        return best_slug, best_sim
+    return None, best_sim
+
+
 def _project_from_cwd(cwd: str | None) -> str | None:
     """Derive a project slug from a CWD path's basename (#145).
 
@@ -1205,11 +1315,12 @@ def _project_from_cwd(cwd: str | None) -> str | None:
 
 
 @app.post("/session-end")
-def session_end_api(req: SessionEndRequest) -> dict[str, Any]:
+def session_end_api(req: SessionEndRequest, request: Request = None) -> dict[str, Any]:
     """Capture session outcomes to daily notes and project status files."""
     today = _utc_now().strftime("%Y-%m-%d")
     now_iso = _utc_now().isoformat().replace("+00:00", "Z")
-    source = req.source or os.environ.get("PALINODE_SOURCE", "api")
+    # ADR-010 / #167: same precedence as save_api — explicit > header > env > default.
+    source = _resolve_source(req.source, request)
 
     # Auto-derive project from cwd if caller didn't pass one (#145).
     project = req.project or _project_from_cwd(req.cwd)
@@ -1267,39 +1378,52 @@ def session_end_api(req: SessionEndRequest) -> dict[str, Any]:
                 f.write(f"\n- [{today}] {one_liner}\n")
             status_file = f"projects/{project}-status.md"
 
+    # Semantic dedup against recent saves (#126). The daily note + project
+    # status file are append-only logs we always write — only the indexed
+    # individual file is suppressed when a near-duplicate already exists,
+    # because that file's value is the standalone embedding/searchable record
+    # which we'd otherwise have twice for the same content.
+    deduplicated_against, dedup_similarity = _check_session_end_dedup(session_entry)
+
     # Also save as an individual indexed memory file (M0: dual-write).
     # This gives each session-end its own frontmatter, entities, description,
     # and embedding — searchable and retractable independently.
     individual_file = None
-    try:
-        short_hash = hashlib.sha256(req.summary.encode()).hexdigest()[:8]
-        # Pass structured metadata through to the indexed file's frontmatter so
-        # it's queryable later (#145). Only include fields the caller set.
-        extra_meta: dict[str, Any] = {}
-        if req.harness:
-            extra_meta["harness"] = req.harness
-        if req.cwd:
-            extra_meta["cwd"] = req.cwd
-        if req.model:
-            extra_meta["model"] = req.model
-        if req.trigger:
-            extra_meta["trigger"] = req.trigger
-        if req.session_id:
-            extra_meta["session_id"] = req.session_id
-        if req.duration_seconds is not None:
-            extra_meta["duration_seconds"] = req.duration_seconds
-        save_req = SaveRequest(
-            content=session_entry,
-            type="ProjectSnapshot" if project else "Insight",
-            slug=f"session-end-{today}-{project}-{short_hash}" if project else f"session-end-{today}-{short_hash}",
-            entities=[f"project/{project}"] if project else [],
-            source=source,
-            metadata=extra_meta or None,
+    if deduplicated_against is not None:
+        logger.info(
+            f"session_end dedup: matched {deduplicated_against} (sim={dedup_similarity:.2f}) "
+            f"— skipping individual file"
         )
-        save_result = save_api(save_req)
-        individual_file = save_result.get("file_path")
-    except Exception as e:
-        logger.error(f"Individual session-end file save failed (non-fatal): {e}")
+    else:
+        try:
+            short_hash = hashlib.sha256(req.summary.encode()).hexdigest()[:8]
+            # Pass structured metadata through to the indexed file's frontmatter so
+            # it's queryable later (#145). Only include fields the caller set.
+            extra_meta: dict[str, Any] = {}
+            if req.harness:
+                extra_meta["harness"] = req.harness
+            if req.cwd:
+                extra_meta["cwd"] = req.cwd
+            if req.model:
+                extra_meta["model"] = req.model
+            if req.trigger:
+                extra_meta["trigger"] = req.trigger
+            if req.session_id:
+                extra_meta["session_id"] = req.session_id
+            if req.duration_seconds is not None:
+                extra_meta["duration_seconds"] = req.duration_seconds
+            save_req = SaveRequest(
+                content=session_entry,
+                type="ProjectSnapshot" if project else "Insight",
+                slug=f"session-end-{today}-{project}-{short_hash}" if project else f"session-end-{today}-{short_hash}",
+                entities=[f"project/{project}"] if project else [],
+                source=source,
+                metadata=extra_meta or None,
+            )
+            save_result = save_api(save_req)
+            individual_file = save_result.get("file_path")
+        except Exception as e:
+            logger.error(f"Individual session-end file save failed (non-fatal): {e}")
 
     # Git commit (covers daily + status + individual file if save_api didn't commit)
     if config.git.auto_commit:
@@ -1316,12 +1440,15 @@ def session_end_api(req: SessionEndRequest) -> dict[str, Any]:
         except Exception as e:
             logger.error(f"Git commit failed for session-end: {e}")
 
-    return {
+    response: dict[str, Any] = {
         "daily_file": f"daily/{today}.md",
         "status_file": status_file,
         "individual_file": individual_file,
         "entry": session_entry,
     }
+    if deduplicated_against is not None:
+        response["deduplicated_against"] = deduplicated_against
+    return response
 
 
 @app.get("/git-stats")

--- a/palinode/cli/_api.py
+++ b/palinode/cli/_api.py
@@ -1,35 +1,104 @@
 import os
 import httpx
 from palinode.core.config import config
+from palinode.core.defaults import SAVE_SOURCE_HEADER
+
+# Re-exported for CLI commands that need to catch API errors without
+# importing httpx directly (ADR-010: HTTP-layer monopoly).
+HTTPStatusError = httpx.HTTPStatusError
+RequestError = httpx.RequestError
+
 
 class PalinodeAPI:
     def __init__(self):
         self.base_url = os.environ.get(
-            "PALINODE_API", 
-            f"http://{config.services.api.host}:{config.services.api.port}"
+            "PALINODE_API",
+            f"http://{config.services.api.host}:{config.services.api.port}",
         )
-        self.client = httpx.Client(base_url=self.base_url, timeout=30.0)
+        # ADR-010 / #167: every request carries the surface attribution as
+        # a header.  The API uses this when the body doesn't explicitly set
+        # `source`, giving consistent provenance without each surface having
+        # to thread a source default through every call site.
+        self.client = httpx.Client(
+            base_url=self.base_url,
+            timeout=30.0,
+            headers={SAVE_SOURCE_HEADER: "cli"},
+        )
 
-    def search(self, query: str, limit: int = 3, category: str = None, context: list[str] = None):
+    def search(
+        self,
+        query: str,
+        limit: int = 3,
+        category: str | None = None,
+        context: list[str] | None = None,
+        threshold: float | None = None,
+        since_days: int | None = None,
+        types: list[str] | None = None,
+        date_after: str | None = None,
+        date_before: str | None = None,
+        include_daily: bool | None = None,
+    ):
+        # ADR-010 / #163: forward the full canonical search surface.
+        # Non-None params land in the body verbatim; None means "API default".
         payload: dict = {"query": query, "limit": limit}
         if category:
             payload["category"] = category
         if context:
             payload["context"] = context
+        if threshold is not None:
+            payload["threshold"] = threshold
+        if since_days is not None:
+            payload["since_days"] = since_days
+        if types:
+            payload["types"] = list(types)
+        if date_after:
+            payload["date_after"] = date_after
+        if date_before:
+            payload["date_before"] = date_before
+        if include_daily:
+            payload["include_daily"] = True
 
         response = self.client.post("/search", json=payload)
         response.raise_for_status()
         return response.json()
 
-    def save(self, content: str, memory_type: str, entities: list[str] = None, title: str = None, source: str = None, sync: bool = False):
-        payload = {
+    def save(
+        self,
+        content: str,
+        memory_type: str,
+        entities: list[str] = None,
+        title: str | None = None,
+        source: str | None = None,
+        sync: bool = False,
+        project: str | None = None,
+        slug: str | None = None,
+        core: bool | None = None,
+        confidence: float | None = None,
+        metadata: dict | None = None,
+    ):
+        payload: dict = {
             "content": content,
             "type": memory_type,
             "entities": entities or [],
-            "title": title
         }
+        # Only include optional fields when set so the server can apply its
+        # own defaults vs. seeing an explicit ``None``.
+        if title is not None:
+            payload["title"] = title
         if source:
             payload["source"] = source
+        if project:
+            # ADR-010 / #159: project is API-side sugar; the API expands it
+            # into entities.
+            payload["project"] = project
+        if slug is not None:
+            payload["slug"] = slug
+        if core is not None:
+            payload["core"] = core
+        if confidence is not None:
+            payload["confidence"] = confidence
+        if metadata is not None:
+            payload["metadata"] = metadata
         params = {"sync": "true"} if sync else None
         response = self.client.post("/save", json=payload, params=params)
         response.raise_for_status()
@@ -37,6 +106,116 @@ class PalinodeAPI:
 
     def get_status(self):
         response = self.client.get("/status")
+        response.raise_for_status()
+        return response.json()
+
+    def read(self, file_path: str, meta: bool = False):
+        """Read a memory file via the API.
+
+        Returns ``{file, content, size_bytes, [frontmatter]}``.  When
+        ``meta=True``, ``frontmatter`` is a parsed dict.  ADR-010 / #168.
+        """
+        params: dict = {"file_path": file_path}
+        if meta:
+            params["meta"] = "true"
+        response = self.client.get("/read", params=params)
+        response.raise_for_status()
+        return response.json()
+
+    def list_files(self, category: str | None = None, core_only: bool | None = None):
+        """List memory files via the API.  ADR-010 / #170."""
+        params: dict = {}
+        if category:
+            params["category"] = category
+        if core_only:
+            params["core_only"] = "true"
+        response = self.client.get("/list", params=params)
+        response.raise_for_status()
+        return response.json()
+
+    def lint(self):
+        """Run the memory lint pass via the API.  ADR-010 / #170.
+
+        Raises ``RequestError`` if the API is unreachable; the CLI catches
+        this to fall back to a local in-process lint pass.
+        """
+        response = self.client.post("/lint", timeout=30.0)
+        response.raise_for_status()
+        return response.json()
+
+    def list_prompts(self, task: str | None = None):
+        """List stored prompt versions.  ADR-010 / #170."""
+        params: dict = {}
+        if task:
+            params["task"] = task
+        response = self.client.get("/prompts", params=params)
+        response.raise_for_status()
+        return response.json()
+
+    def get_prompt(self, name: str):
+        """Read a specific prompt by name.  ADR-010 / #170."""
+        response = self.client.get(f"/prompts/{name}")
+        response.raise_for_status()
+        return response.json()
+
+    def activate_prompt(self, name: str):
+        """Activate a prompt version.  ADR-010 / #170."""
+        response = self.client.post(f"/prompts/{name}/activate")
+        response.raise_for_status()
+        return response.json()
+
+    def ingest_inbox(self):
+        """Process files in the inbox directory.  ADR-010 / #170."""
+        response = self.client.post("/ingest", timeout=60.0)
+        response.raise_for_status()
+        return response.json()
+
+    def ingest_url(self, url: str, name: str | None = None):
+        """Fetch and save a URL as a research reference.  ADR-010 / #170."""
+        payload: dict = {"url": url}
+        if name:
+            payload["name"] = name
+        response = self.client.post("/ingest-url", json=payload, timeout=60.0)
+        response.raise_for_status()
+        return response.json()
+
+    def session_end(
+        self,
+        summary: str,
+        decisions: list[str] | None = None,
+        blockers: list[str] | None = None,
+        project: str | None = None,
+        source: str | None = None,
+        harness: str | None = None,
+        cwd: str | None = None,
+        model: str | None = None,
+        trigger: str | None = None,
+        session_id: str | None = None,
+        duration_seconds: int | None = None,
+    ):
+        """Capture session outcomes via the API.  ADR-010 / #170 (#145 fields)."""
+        payload: dict = {"summary": summary}
+        if decisions:
+            payload["decisions"] = list(decisions)
+        if blockers:
+            payload["blockers"] = list(blockers)
+        if project:
+            payload["project"] = project
+        if source:
+            payload["source"] = source
+        if harness:
+            payload["harness"] = harness
+        if cwd:
+            payload["cwd"] = cwd
+        if model:
+            payload["model"] = model
+        if trigger:
+            payload["trigger"] = trigger
+        if session_id:
+            payload["session_id"] = session_id
+        if duration_seconds is not None:
+            payload["duration_seconds"] = duration_seconds
+        response = self.client.post("/session-end", json=payload, timeout=30.0)
         response.raise_for_status()
         return response.json()
 
@@ -54,12 +233,28 @@ class PalinodeAPI:
         response.raise_for_status()
         return response.json()
 
-    def trigger_add(self, description: str, memory_file: str, threshold: float = 0.75):
+    def trigger_add(
+        self,
+        description: str,
+        memory_file: str,
+        threshold: float | None = None,
+        cooldown_hours: int | None = None,
+        trigger_id: str | None = None,
+    ):
+        # ADR-010 / #165: forward all four canonical params.  Defaults live
+        # in palinode.core.defaults so the CLI can show them in --help.  We
+        # only include them in the body when non-None so the API still
+        # receives explicit user intent vs implicit defaults.
         payload: dict = {
             "description": description,
             "memory_file": memory_file,
-            "threshold": threshold,
         }
+        if threshold is not None:
+            payload["threshold"] = threshold
+        if cooldown_hours is not None:
+            payload["cooldown_hours"] = cooldown_hours
+        if trigger_id is not None:
+            payload["trigger_id"] = trigger_id
         response = self.client.post("/triggers", json=payload)
         response.raise_for_status()
         return response.json()

--- a/palinode/cli/git.py
+++ b/palinode/cli/git.py
@@ -26,12 +26,40 @@ def history(file_path, limit):
 
 @click.command()
 @click.argument("file_path")
-@click.argument("commit")
-@click.option("--execute", is_flag=True, help="Actually apply (default: dry run)")
-def rollback(file_path, commit, execute):
-    """Revert a file."""
+@click.argument("commit", required=False)
+@click.option(
+    "--dry-run/--no-dry-run",
+    "dry_run",
+    default=True,
+    help="Preview the change without applying.  Default: --dry-run.",
+)
+@click.option(
+    "--execute",
+    is_flag=True,
+    default=False,
+    help=(
+        "Deprecated alias for --no-dry-run (ADR-010 / #164).  Will be "
+        "removed in a future release."
+    ),
+)
+def rollback(file_path, commit, dry_run, execute):
+    """Revert a file to a previous commit.
+
+    By default this is a dry run — pass ``--no-dry-run`` to actually
+    apply the rollback.  ``COMMIT`` is optional; when omitted, rolls
+    back to the immediately previous version.
+    """
+    # ADR-010 / #164: --execute is a deprecated alias for --no-dry-run.
+    # The Click pair --dry-run/--no-dry-run is the canonical convention
+    # matching MCP and API.
+    if execute:
+        click.echo(
+            "warning: --execute is deprecated; use --no-dry-run instead.",
+            err=True,
+        )
+        dry_run = False
     try:
-        data = api_client.rollback(file_path, commit, dry_run=not execute)
+        data = api_client.rollback(file_path, commit, dry_run=dry_run)
         console.print(data)
     except Exception as e:
         console.print(f"[red]Error rolling back: {str(e)}[/red]")

--- a/palinode/cli/ingest.py
+++ b/palinode/cli/ingest.py
@@ -1,6 +1,5 @@
 import click
-import httpx
-from palinode.core.config import config
+from palinode.cli._api import HTTPStatusError, RequestError, api_client
 from palinode.cli._format import console, print_result, get_default_format, OutputFormat
 
 
@@ -14,29 +13,17 @@ def ingest(url, name, inbox, fmt):
     if not url and not inbox:
         raise click.UsageError("Provide --url <URL> or --inbox")
 
-    api_port = config.services.api.port
     output_fmt = OutputFormat(fmt) if fmt else get_default_format()
 
     try:
         if inbox:
-            resp = httpx.post(f"http://127.0.0.1:{api_port}/ingest", timeout=60.0)
-            resp.raise_for_status()
-            data = resp.json()
+            data = api_client.ingest_inbox()
             if output_fmt == OutputFormat.JSON:
                 print_result(data, fmt=output_fmt)
             else:
                 console.print("[green]✓[/green] Inbox processed.")
         else:
-            payload = {"url": url}
-            if name:
-                payload["name"] = name
-            resp = httpx.post(
-                f"http://127.0.0.1:{api_port}/ingest-url",
-                json=payload,
-                timeout=60.0,
-            )
-            resp.raise_for_status()
-            data = resp.json()
+            data = api_client.ingest_url(url=url, name=name)
             if output_fmt == OutputFormat.JSON:
                 print_result(data, fmt=output_fmt)
             else:
@@ -44,12 +31,12 @@ def ingest(url, name, inbox, fmt):
                     console.print(f"[green]✓[/green] Saved to {data.get('file_path', 'research/')}")
                 else:
                     console.print("[yellow]No content extracted from URL.[/yellow]")
-    except httpx.HTTPStatusError as e:
+    except HTTPStatusError as e:
         detail = ""
         try:
             detail = e.response.json().get("detail", "")
         except Exception:
             pass
         console.print(f"[red]Error:[/red] {detail or e.response.status_code}")
-    except httpx.RequestError as e:
+    except RequestError as e:
         console.print(f"[red]Error:[/red] Cannot reach API — is palinode running? ({e})")

--- a/palinode/cli/lint.py
+++ b/palinode/cli/lint.py
@@ -1,9 +1,8 @@
 import click
 import json
-import httpx
 from rich.console import Console
 
-from palinode.core.config import config
+from palinode.cli._api import HTTPStatusError, RequestError, api_client
 
 console = Console()
 
@@ -11,15 +10,12 @@ console = Console()
 @click.option("--format", "fmt", type=click.Choice(["json", "text"]), default="text", help="Output format")
 def lint(fmt):
     """Scan memory and report orphans, stale files, and contradictions."""
-    api_url = f"http://localhost:{config.services.api.port}/lint"
-    
     try:
-        resp = httpx.post(api_url, timeout=30.0)
-        if resp.status_code != 200:
-            console.print(f"[red]Error: API returned {resp.status_code}[/red]")
-            return
-        data = resp.json()
-    except httpx.RequestError:
+        data = api_client.lint()
+    except HTTPStatusError as e:
+        console.print(f"[red]Error: API returned {e.response.status_code}[/red]")
+        return
+    except RequestError:
         # Fallback to local import if API is down
         from palinode.core.lint import run_lint_pass
         data = run_lint_pass()
@@ -29,32 +25,32 @@ def lint(fmt):
         return
 
     console.print(f"\n[bold green]Palinode Memory Lint Report[/bold green]\n")
-    
+
     if data["missing_fields"]:
         console.print(f"[bold yellow]Missing Frontmatter ({len(data['missing_fields'])})[/bold yellow]")
         for mf in data["missing_fields"]:
              console.print(f"  - {mf['file']}: missing {', '.join(mf['missing'])}")
     else:
         console.print("[green]✓ No files missing frontmatter[/green]")
-        
+
     console.print("")
-        
+
     if data["orphaned_files"]:
         console.print(f"[bold yellow]Orphaned Files ({len(data['orphaned_files'])})[/bold yellow]")
         for of in data["orphaned_files"]:
              console.print(f"  - {of}")
     else:
         console.print("[green]✓ No orphaned files[/green]")
-        
+
     console.print("")
-        
+
     if data["stale_files"]:
         console.print(f"[bold yellow]Stale Active Files ({len(data['stale_files'])})[/bold yellow]")
         for sf in data["stale_files"]:
              console.print(f"  - {sf['file']} ({sf['days_old']} days old)")
     else:
         console.print("[green]✓ No stale active files (>90 days)[/green]")
-        
+
     console.print("")
 
     if data["contradictions"]:

--- a/palinode/cli/list.py
+++ b/palinode/cli/list.py
@@ -1,9 +1,6 @@
 import click
 from palinode.cli._api import api_client
 from palinode.cli._format import console, print_result, get_default_format, OutputFormat
-import httpx
-from palinode.core.config import config
-import os
 
 @click.command()
 @click.option("--category", type=click.Choice(["people", "projects", "decisions", "insights", "research"]))
@@ -12,26 +9,17 @@ import os
 def list_cmd(category, core_only, fmt):
     """List memory files."""
     try:
-        api_port = config.services.api.port
-        params = {}
-        if category:
-            params["category"] = category
-        if core_only:
-            params["core_only"] = "true"
-            
-        resp = httpx.get(f"http://127.0.0.1:{api_port}/list", params=params, timeout=30.0)
-        resp.raise_for_status()
-        data = resp.json()
-        
+        data = api_client.list_files(category=category, core_only=core_only)
+
         output_fmt = OutputFormat(fmt) if fmt else get_default_format()
-        
+
         if output_fmt == OutputFormat.JSON:
             print_result(data, fmt=output_fmt)
         else:
             if not data:
                 console.print("No files found.")
                 return
-                
+
             # Group by category for text output
             from collections import defaultdict
             grouped = defaultdict(list)
@@ -40,7 +28,7 @@ def list_cmd(category, core_only, fmt):
                 grouped[item["category"]].append(item)
                 if item["core"]:
                     core_count += 1
-                    
+
             for cat, items in grouped.items():
                 console.print(f"[bold blue]{cat}/[/bold blue]")
                 for item in items:
@@ -52,9 +40,9 @@ def list_cmd(category, core_only, fmt):
                     else:
                         console.print(f"  {name:<16}{core_tag}")
                 console.print("")
-                
+
             console.print(f"[bold]{len(data)} files ({core_count} core)[/bold]")
-            
+
     except Exception as e:
         console.print(f"[red]Error listing files: {str(e)}[/red]")
         click.Abort()

--- a/palinode/cli/prompt.py
+++ b/palinode/cli/prompt.py
@@ -1,16 +1,9 @@
 """CLI commands for managing versioned LLM prompts stored as memory files."""
-import json
-
 import click
-import httpx
 from rich.table import Table
 
-from palinode.core.config import config
+from palinode.cli._api import HTTPStatusError, api_client
 from palinode.cli._format import console, get_default_format, OutputFormat, print_result
-
-
-def _api_url(path: str) -> str:
-    return f"http://{config.services.api.host}:{config.services.api.port}{path}"
 
 
 @click.group()
@@ -25,14 +18,8 @@ def prompt():
 @click.option("--format", "fmt", type=click.Choice(["text", "json"]), default=None)
 def prompt_list(task: str | None, fmt: str | None) -> None:
     """List all stored prompt versions."""
-    params: dict = {}
-    if task:
-        params["task"] = task
-
     try:
-        resp = httpx.get(_api_url("/prompts"), params=params, timeout=30.0)
-        resp.raise_for_status()
-        data = resp.json()
+        data = api_client.list_prompts(task=task)
     except Exception as e:
         console.print(f"[red]Error listing prompts: {e}[/red]")
         raise click.Abort()
@@ -73,14 +60,13 @@ def prompt_list(task: str | None, fmt: str | None) -> None:
 def prompt_show(name: str, fmt: str | None) -> None:
     """Display the content of a specific prompt."""
     try:
-        resp = httpx.get(_api_url(f"/prompts/{name}"), timeout=30.0)
-        if resp.status_code == 404:
+        data = api_client.get_prompt(name)
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
             console.print(f"[red]Prompt '{name}' not found.[/red]")
             raise click.Abort()
-        resp.raise_for_status()
-        data = resp.json()
-    except click.Abort:
-        raise
+        console.print(f"[red]Error reading prompt: {e}[/red]")
+        raise click.Abort()
     except Exception as e:
         console.print(f"[red]Error reading prompt: {e}[/red]")
         raise click.Abort()
@@ -103,14 +89,13 @@ def prompt_show(name: str, fmt: str | None) -> None:
 def prompt_activate(name: str, fmt: str | None) -> None:
     """Activate a prompt version (deactivates others of the same task)."""
     try:
-        resp = httpx.post(_api_url(f"/prompts/{name}/activate"), timeout=30.0)
-        if resp.status_code == 404:
+        data = api_client.activate_prompt(name)
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
             console.print(f"[red]Prompt '{name}' not found.[/red]")
             raise click.Abort()
-        resp.raise_for_status()
-        data = resp.json()
-    except click.Abort:
-        raise
+        console.print(f"[red]Error activating prompt: {e}[/red]")
+        raise click.Abort()
     except Exception as e:
         console.print(f"[red]Error activating prompt: {e}[/red]")
         raise click.Abort()

--- a/palinode/cli/read.py
+++ b/palinode/cli/read.py
@@ -1,37 +1,42 @@
-import click
+"""
+``palinode read`` — fetch a memory file via the API.
+
+Per ADR-010 (#168), this command goes through ``palinode/cli/_api.py``
+rather than reading disk directly.  Path validation, traversal
+protection, and ``.md`` extension fallback live server-side in the
+``/read`` handler — the CLI is now a thin presenter.
+"""
+from __future__ import annotations
+
 import json
-import os
 from datetime import date, datetime
-from palinode.core.config import config
-from palinode.cli._format import print_result, get_default_format, OutputFormat
+from typing import Any
 
+import click
 
-def _resolve_memory_path(file_path: str) -> tuple[str, str]:
-    """Resolve a relative memory path without allowing traversal outside memory_dir."""
-    if "\x00" in file_path:
-        raise click.ClickException("Null bytes are not allowed in paths")
-    if os.path.isabs(file_path):
-        raise click.ClickException("Absolute paths are not allowed")
-
-    base_dir = os.path.realpath(config.memory_dir)
-    resolved = os.path.realpath(os.path.join(base_dir, file_path))
-    try:
-        within_root = os.path.commonpath([base_dir, resolved]) == base_dir
-    except ValueError as exc:
-        raise click.ClickException("Invalid path") from exc
-    if not within_root:
-        raise click.ClickException("Path traversal rejected")
-    return base_dir, resolved
+from palinode.cli._api import HTTPStatusError, api_client
+from palinode.cli._format import OutputFormat, get_default_format
 
 
 @click.command()
 @click.argument("file_path")
-@click.option("--format", "fmt", type=click.Choice(["text", "json"]), default=None, help="Output format")
-@click.option("--meta/--no-meta", default=False, help="Include YAML frontmatter metadata as structured JSON")
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["text", "json"]),
+    default=None,
+    help="Output format",
+)
+@click.option(
+    "--meta/--no-meta",
+    default=False,
+    help="Include YAML frontmatter as structured data",
+)
 def read(file_path, fmt, meta):
     """Read a specific memory file.
 
-    FILE_PATH is relative to the memory directory (e.g., "people/peter.md", "decisions/cli-pivot.md").
+    FILE_PATH is relative to the memory directory (e.g., "people/peter.md",
+    "decisions/cli-pivot.md").
 
     Examples:
 
@@ -39,69 +44,58 @@ def read(file_path, fmt, meta):
 
         palinode read projects/palinode-status.md --meta --format json
     """
-    _, full_path = _resolve_memory_path(file_path)
+    try:
+        result = api_client.read(file_path, meta=meta)
+    except HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise click.ClickException(f"File not found: {file_path}") from e
+        raise click.ClickException(f"Read failed: {e.response.text}") from e
 
-    if not os.path.exists(full_path):
-        if not file_path.endswith(".md"):
-            file_path = f"{file_path}.md"
-            _, full_path = _resolve_memory_path(file_path)
-        if not os.path.exists(full_path):
-            raise click.ClickException(f"File not found: {file_path}")
-
-    with open(full_path, "r") as f:
-        content = f.read()
+    effective_fmt = OutputFormat(fmt) if fmt else get_default_format()
 
     if meta:
-        # Parse frontmatter
-        frontmatter = {}
-        body = content
-        if content.startswith("---"):
-            parts = content.split("---", 2)
-            if len(parts) >= 3:
-                try:
-                    import yaml
-                    frontmatter = yaml.safe_load(parts[1]) or {}
-                except Exception:
-                    pass
-                body = parts[2].strip()
-
-        result = {
-            "file": file_path,
-            "path": full_path,
-            "frontmatter": frontmatter,
-            "content": body,
-            "size_bytes": os.path.getsize(full_path),
-        }
-        effective_fmt = OutputFormat(fmt) if fmt else get_default_format()
         if effective_fmt == OutputFormat.JSON:
             click.echo(json.dumps(result, indent=2, default=_json_default))
         else:
             click.echo(_format_with_meta(result))
     else:
-        if fmt == "json":
-            result = {
-                "file": file_path,
-                "content": content,
-                "size_bytes": os.path.getsize(full_path),
-            }
-            click.echo(json.dumps(result, indent=2))
+        if effective_fmt == OutputFormat.JSON:
+            # Drop frontmatter from the no-meta JSON view for symmetry with
+            # the API's no-meta response shape.
+            slim = {k: v for k, v in result.items() if k != "frontmatter"}
+            click.echo(json.dumps(slim, indent=2, default=_json_default))
         else:
-            click.echo(content)
+            click.echo(result.get("content", ""))
 
 
-def _json_default(obj):
+def _json_default(obj: Any):
     if isinstance(obj, (datetime, date)):
         return obj.isoformat()
     return str(obj)
 
 
-def _format_with_meta(result):
-    lines = []
-    if result.get("frontmatter"):
+def _format_with_meta(result: dict) -> str:
+    lines: list[str] = []
+    fm = result.get("frontmatter") or {}
+    if fm:
         lines.append("── Frontmatter ──")
-        for k, v in result["frontmatter"].items():
+        for k, v in fm.items():
             lines.append(f"  {k}: {v}")
         lines.append("")
     lines.append("── Content ──")
-    lines.append(result["content"])
+    # When meta=True, the API returns the full file content (frontmatter +
+    # body).  Strip the leading frontmatter block for cleaner CLI output.
+    content = result.get("content", "")
+    body = _strip_frontmatter(content)
+    lines.append(body)
     return "\n".join(lines)
+
+
+def _strip_frontmatter(content: str) -> str:
+    """If `content` starts with `---`, drop the frontmatter block."""
+    if not content.startswith("---"):
+        return content
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return content
+    return parts[2].lstrip("\n")

--- a/palinode/cli/save.py
+++ b/palinode/cli/save.py
@@ -1,3 +1,5 @@
+import json as _json
+
 import click
 from palinode.cli._api import api_client
 from palinode.cli._format import console, print_result, get_default_format, OutputFormat
@@ -7,8 +9,44 @@ from palinode.cli._format import console, print_result, get_default_format, Outp
 @click.option("--type", "memory_type", required=False, help="Memory type (e.g. PersonMemory, Decision, Insight, ProjectSnapshot)")
 @click.option("--ps", "is_ps", is_flag=True, help="Shorthand for --type ProjectSnapshot (Palinode Save a mid-session snapshot)")
 @click.option("--entity", "entities", multiple=True, help="Entity tag (e.g. person/X, project/X)")
+@click.option(
+    "-p",
+    "--project",
+    help="Project slug shorthand — e.g. 'palinode' becomes entity 'project/palinode'. "
+         "Pairs with `palinode session-end -p` for consistent project tagging.",
+)
 @click.option("--file", "file_path", type=click.Path(exists=True), help="Read content from file instead of argument")
 @click.option("--title", help="Optional title override")
+@click.option(
+    "--slug",
+    help="URL-safe filename slug.  Auto-generated from content if omitted.",
+)
+@click.option(
+    "--core/--no-core",
+    "core",
+    default=None,
+    help=(
+        "Mark this memory as core (always injected at session start).  "
+        "Defaults to unset (regular memory)."
+    ),
+)
+@click.option(
+    "--confidence",
+    type=float,
+    help=(
+        "Confidence in this memory's accuracy (0.0–1.0).  Stored as "
+        "frontmatter; consumed by consolidation."
+    ),
+)
+@click.option(
+    "--metadata-json",
+    "metadata",
+    help=(
+        "Extra frontmatter fields as a JSON object string, "
+        "e.g. --metadata-json '{\"topic\": \"deployment\"}'.  "
+        "Parsed before sending — matches the API's `metadata` field."
+    ),
+)
 @click.option("--source", help="Source surface (e.g., claude-code, cursor, api)")
 @click.option(
     "--sync/--no-sync",
@@ -18,7 +56,22 @@ from palinode.cli._format import console, print_result, get_default_format, Outp
          "consolidation.write_time.enabled in config.",
 )
 @click.option("--format", "fmt", type=click.Choice(["json", "text"]), help="Output format")
-def save(content, memory_type, is_ps, entities, file_path, title, source, sync, fmt):
+def save(
+    content,
+    memory_type,
+    is_ps,
+    entities,
+    project,
+    file_path,
+    title,
+    slug,
+    core,
+    confidence,
+    metadata,
+    source,
+    sync,
+    fmt,
+):
     """Store a new memory.
 
     Use --ps as shorthand for --type ProjectSnapshot when dropping a quick
@@ -46,15 +99,39 @@ def save(content, memory_type, is_ps, entities, file_path, title, source, sync, 
         click.Abort()
         return
 
+    # Parse --metadata-json into a dict.  Reject non-object payloads to
+    # keep the API contract clear (metadata merges into a dict frontmatter).
+    if metadata:
+        raw = metadata
+        try:
+            metadata = _json.loads(raw)
+        except _json.JSONDecodeError as e:
+            console.print(f"[red]Error: --metadata-json is not valid JSON: {e}[/red]")
+            click.Abort()
+            return
+        if not isinstance(metadata, dict):
+            console.print("[red]Error: --metadata-json must be a JSON object.[/red]")
+            click.Abort()
+            return
+    else:
+        metadata = None
+
     try:
-        source_val = source or "cli"
+        # ADR-010 / #167: do not default source here.  The HTTP client sets
+        # X-Palinode-Source: cli on every request; only forward `source` in
+        # the body when the user explicitly passed --source.
         result = api_client.save(
             content,
             memory_type,
             entities=list(entities),
             title=title,
-            source=source_val,
+            source=source,
             sync=sync,
+            project=project,
+            slug=slug,
+            core=core,
+            confidence=confidence,
+            metadata=metadata,
         )
 
         output_fmt = OutputFormat(fmt) if fmt else get_default_format()

--- a/palinode/cli/search.py
+++ b/palinode/cli/search.py
@@ -7,7 +7,7 @@ from rich.panel import Panel
 
 
 def _cli_resolve_context() -> list[str] | None:
-    """Resolve ambient project context from CWD for CLI."""
+    """Resolve ambient project context from CWD for CLI (ADR-008)."""
     if not config.context.enabled:
         return None
     explicit = os.environ.get("PALINODE_PROJECT")
@@ -27,15 +27,75 @@ def _cli_resolve_context() -> list[str] | None:
 @click.command()
 @click.argument("query")
 @click.option("--limit", default=3, help="Number of results (default: 3)")
-@click.option("--category", help="Filter by memory type/category")
+@click.option(
+    "--category",
+    type=click.Choice(["people", "projects", "decisions", "insights", "research"]),
+    help="Filter by memory directory (people, projects, decisions, insights, research)",
+)
+@click.option(
+    "--threshold",
+    type=float,
+    help="Similarity threshold (0.0–1.0).  Higher = stricter; default from config.",
+)
+@click.option(
+    "--since-days",
+    type=int,
+    help="Only return memories created/updated in the last N days.",
+)
+@click.option(
+    "--types",
+    "types",
+    multiple=True,
+    help=(
+        "Filter by memory type (PersonMemory, Decision, ProjectSnapshot, Insight, "
+        "ResearchRef, ActionItem).  Repeat to allow multiple."
+    ),
+)
+@click.option(
+    "--date-after",
+    help="Only return memories created/updated after this ISO date (e.g. 2026-01-01).",
+)
+@click.option(
+    "--date-before",
+    help="Only return memories created/updated before this ISO date.",
+)
+@click.option(
+    "--include-daily",
+    is_flag=True,
+    help="Include daily/ session notes at full rank (default: penalized).",
+)
 @click.option("--format", "fmt", type=click.Choice(["json", "text"]), help="Output format")
 @click.option("--score/--no-score", default=False, help="Show relevance scores")
 @click.option("--no-context", is_flag=True, help="Disable ambient context boost")
-def search(query, limit, category, fmt, score, no_context):
+def search(
+    query,
+    limit,
+    category,
+    threshold,
+    since_days,
+    types,
+    date_after,
+    date_before,
+    include_daily,
+    fmt,
+    score,
+    no_context,
+):
     """Search memory by meaning or keyword."""
     try:
         context = None if no_context else _cli_resolve_context()
-        results = api_client.search(query, limit=limit, category=category, context=context)
+        results = api_client.search(
+            query,
+            limit=limit,
+            category=category,
+            context=context,
+            threshold=threshold,
+            since_days=since_days,
+            types=list(types) if types else None,
+            date_after=date_after,
+            date_before=date_before,
+            include_daily=include_daily or None,
+        )
         
         output_fmt = OutputFormat(fmt) if fmt else get_default_format()
         

--- a/palinode/cli/session_end.py
+++ b/palinode/cli/session_end.py
@@ -1,9 +1,5 @@
 import click
-import hashlib
-import json
-import os
-from datetime import datetime, timezone
-from palinode.core.config import config
+from palinode.cli._api import HTTPStatusError, RequestError, api_client
 from palinode.cli._format import print_result, get_default_format, OutputFormat
 
 
@@ -13,8 +9,15 @@ from palinode.cli._format import print_result, get_default_format, OutputFormat
 @click.option("--blocker", "-b", multiple=True, help="Open blocker or next step (repeatable)")
 @click.option("--project", "-p", default=None, help="Project slug to append status to (e.g., 'palinode')")
 @click.option("--source", help="Source surface (e.g., claude-code, cursor, api)")
+@click.option("--harness", help="Harness identifier (e.g., claude-code, cursor) — #145")
+@click.option("--cwd", help="Working directory the session ran in — #145")
+@click.option("--model", help="Model name (e.g., claude-opus-4-7) — #145")
+@click.option("--trigger", help="What triggered this save (manual, wrap-slash, hook, …) — #145")
+@click.option("--session-id", "session_id", help="Opaque session id from the harness — #145")
+@click.option("--duration-seconds", "duration_seconds", type=int, help="Session duration in seconds — #145")
 @click.option("--format", "fmt", type=click.Choice(["text", "json"]), default=None, help="Output format")
-def session_end(summary, decision, blocker, project, source, fmt):
+def session_end(summary, decision, blocker, project, source, harness, cwd, model,
+                trigger, session_id, duration_seconds, fmt):
     """Capture session outcomes to daily notes and project status.
 
     Call at the end of a coding or chat session to persist what was accomplished.
@@ -25,96 +28,47 @@ def session_end(summary, decision, blocker, project, source, fmt):
 
         palinode session-end "Fixed embedding timeout" -d "Increase batch size" -b "Test under load" -p palinode
     """
-    now = datetime.now(timezone.utc)
-    today = now.strftime("%Y-%m-%d")
-    now_iso = now.isoformat()
-
-    # Build session entry
-    source_val = source or "cli"
-    parts = [f"## Session End — {now_iso}\n"]
-    parts.append(f"**Source:** {source_val}\n")
-    parts.append(f"**Summary:** {summary}\n")
-
     decisions = list(decision)
     blockers = list(blocker)
 
-    if decisions:
-        parts.append("**Decisions:**")
-        for d in decisions:
-            parts.append(f"- {d}")
-        parts.append("")
-    if blockers:
-        parts.append("**Blockers/Next:**")
-        for b in blockers:
-            parts.append(f"- {b}")
-        parts.append("")
-
-    session_entry = "\n".join(parts)
-
-    # Write to daily notes
-    daily_dir = os.path.join(config.memory_dir, "daily")
-    os.makedirs(daily_dir, exist_ok=True)
-    daily_path = os.path.join(daily_dir, f"{today}.md")
-    with open(daily_path, "a") as f:
-        f.write(f"\n{session_entry}\n")
-
-    # Append status to project -status.md if project specified
-    status_msg = ""
-    if project:
-        status_path = os.path.join(config.memory_dir, "projects", f"{project}-status.md")
-        if os.path.exists(status_path):
-            one_liner = summary.replace("\n", " ").strip()[:200]
-            with open(status_path, "a") as f:
-                f.write(f"\n- [{today}] {one_liner}\n")
-            status_msg = f" + status → {project}-status.md"
-
-    # Also save as an individual indexed memory file (M0: dual-write)
-    individual_file = None
     try:
-        import httpx
-        short_hash = hashlib.sha256(summary.encode()).hexdigest()[:8]
-        api_url = f"http://localhost:{config.services.api.port}/save"
-        save_payload = {
-            "content": session_entry,
-            "type": "ProjectSnapshot" if project else "Insight",
-            "slug": f"session-end-{today}-{project}-{short_hash}" if project else f"session-end-{today}-{short_hash}",
-            "entities": [f"project/{project}"] if project else [],
-            "source": source_val,
-        }
-        resp = httpx.post(api_url, json=save_payload, timeout=10.0)
-        if resp.status_code == 200:
-            individual_file = resp.json().get("file_path")
-    except Exception:
-        pass  # Non-fatal — daily append is the primary path
-
-    # Git commit
-    try:
-        import subprocess
-        files_to_add = [daily_path]
-        if project and status_msg:
-            files_to_add.append(os.path.join(config.memory_dir, "projects", f"{project}-status.md"))
-        subprocess.run(
-            ["git", "-C", config.memory_dir, "add"] + files_to_add,
-            capture_output=True, check=False
+        result = api_client.session_end(
+            summary=summary,
+            decisions=decisions,
+            blockers=blockers,
+            project=project,
+            source=source,
+            harness=harness,
+            cwd=cwd,
+            model=model,
+            trigger=trigger,
+            session_id=session_id,
+            duration_seconds=duration_seconds,
         )
-        subprocess.run(
-            ["git", "-C", config.memory_dir, "commit", "-m", f"session-end: {summary[:72]}"],
-            capture_output=True, check=False
-        )
-    except Exception:
-        pass  # Non-fatal if git fails
+    except HTTPStatusError as e:
+        raise click.ClickException(f"Session-end failed: {e.response.text}") from e
+    except RequestError as e:
+        raise click.ClickException(f"Cannot reach API — is palinode running? ({e})") from e
 
-    result = {
-        "daily_file": f"daily/{today}.md",
-        "individual_file": individual_file,
-        "project_status": f"projects/{project}-status.md" if status_msg else None,
-        "summary": summary,
-        "decisions": decisions,
-        "blockers": blockers,
-    }
+    daily_file = result.get("daily_file")
+    status_file = result.get("status_file")
+    individual_file = result.get("individual_file")
+    entry = result.get("entry", "")
 
     effective_fmt = OutputFormat(fmt) if fmt else get_default_format()
     if effective_fmt == OutputFormat.JSON:
-        print_result(result, OutputFormat.JSON)
+        # Preserve the prior CLI JSON shape: callers that script against
+        # `palinode session-end --format json` should still see summary/
+        # decisions/blockers and `project_status` (alias for `status_file`).
+        out = {
+            "daily_file": daily_file,
+            "individual_file": individual_file,
+            "project_status": status_file,
+            "summary": summary,
+            "decisions": decisions,
+            "blockers": blockers,
+        }
+        print_result(out, OutputFormat.JSON)
     else:
-        click.echo(f"Session captured → daily/{today}.md{status_msg}\n\n{session_entry}")
+        status_msg = f" + status → {status_file.split('/')[-1]}" if status_file else ""
+        click.echo(f"Session captured → {daily_file}{status_msg}\n\n{entry}")

--- a/palinode/cli/trigger.py
+++ b/palinode/cli/trigger.py
@@ -1,6 +1,10 @@
 import click
 from palinode.cli._api import api_client
 from palinode.cli._format import console, print_result, get_default_format, OutputFormat
+from palinode.core.defaults import (
+    TRIGGER_COOLDOWN_HOURS_DEFAULT,
+    TRIGGER_THRESHOLD_DEFAULT,
+)
 from rich.table import Table
 
 @click.group()
@@ -11,12 +15,35 @@ def trigger():
 @trigger.command(name="add")
 @click.argument("description")
 @click.option("--file", "memory_file", required=True, help="Memory file to trigger")
-@click.option("--threshold", type=float, default=0.75, help="Similarity threshold (0.0 to 1.0)")
+@click.option(
+    "--threshold",
+    type=float,
+    default=TRIGGER_THRESHOLD_DEFAULT,
+    help=f"Similarity threshold (0.0 to 1.0; default {TRIGGER_THRESHOLD_DEFAULT})",
+)
+@click.option(
+    "--cooldown-hours",
+    type=int,
+    default=TRIGGER_COOLDOWN_HOURS_DEFAULT,
+    help=f"Hours to wait between firings of the same trigger "
+         f"(default {TRIGGER_COOLDOWN_HOURS_DEFAULT})",
+)
+@click.option(
+    "--trigger-id",
+    "trigger_id",
+    help="Stable trigger ID (UUID or slug).  Useful for re-creation / dedup.",
+)
 @click.option("--format", "fmt", type=click.Choice(["json", "text"]), help="Output format")
-def trigger_add(description, memory_file, threshold, fmt):
+def trigger_add(description, memory_file, threshold, cooldown_hours, trigger_id, fmt):
     """Register a new auto-surface trigger."""
     try:
-        result = api_client.trigger_add(description, memory_file, threshold)
+        result = api_client.trigger_add(
+            description,
+            memory_file,
+            threshold=threshold,
+            cooldown_hours=cooldown_hours,
+            trigger_id=trigger_id,
+        )
         
         output_fmt = OutputFormat(fmt) if fmt else get_default_format()
         if output_fmt == OutputFormat.JSON:

--- a/palinode/consolidation/layer_split.py
+++ b/palinode/consolidation/layer_split.py
@@ -115,7 +115,10 @@ def split_file(file_path: str) -> dict:
     id_meta = dict(metadata)
     id_meta['core'] = True
     id_meta['layer'] = 'identity'
-    id_meta['last_updated'] = _utc_now().strftime("%Y-%m-%dT%H:%M:%SZ")
+    # #193: emit timezone-aware UTC ISO-8601 (``+00:00``) rather than
+    # ``strftime("...Z")``, which silently drops sub-second precision and
+    # diverges from the project standard set by #192.
+    id_meta['last_updated'] = _utc_now().isoformat()
     id_content = f"---\n{yaml.dump(id_meta, default_flow_style=False)}---\n\n"
     id_content += "\n\n".join(identity_sections)
     
@@ -132,7 +135,7 @@ def split_file(file_path: str) -> dict:
             'core': True,
             'layer': 'status',
             'parent': id_meta.get('id', name),
-            'last_updated': _utc_now().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            'last_updated': _utc_now().isoformat(),  # #193
         }
         if metadata.get('summary'):
             st_meta['summary'] = f"Current status: {metadata['summary'][:80]}"
@@ -155,7 +158,7 @@ def split_file(file_path: str) -> dict:
             'core': False,
             'layer': 'history',
             'parent': id_meta.get('id', name),
-            'created_at': _utc_now().strftime("%Y-%m-%dT%H:%M:%SZ"),
+            'created_at': _utc_now().isoformat(),  # #193
         }
         if metadata.get('entities'):
             h_meta['entities'] = metadata['entities']

--- a/palinode/consolidation/runner.py
+++ b/palinode/consolidation/runner.py
@@ -338,7 +338,10 @@ def _write_project_summary(project_id: str, consolidation: dict) -> None:
     
     # Simple write, but realistically we'd merge with existing body/frontmatter.
     # We will log the new summary block or replace the content.
-    now = _utc_now().strftime("%Y-%m-%d %H:%M:%SZ")
+    # #193: human-readable UTC log heading. Previously used a literal ``Z``
+    # suffix which trips the project-wide ``strftime("...Z")`` audit; ``UTC``
+    # is unambiguous and keeps the log scannable.
+    now = _utc_now().strftime("%Y-%m-%d %H:%M:%S UTC")
     
     status_bullets = consolidation.get("status_bullets", [])
     bullets_text = "\n".join(f"- {b}" for b in status_bullets)

--- a/palinode/consolidation/write_time.py
+++ b/palinode/consolidation/write_time.py
@@ -1,5 +1,5 @@
 """
-Tier 2a: Write-time contradiction check on palinode_save.
+Tier 2a: Write-time contradiction check on palinode_save (ADR-004).
 
 When enabled, every save schedules a background contradiction check against
 similar existing memories. Runs asynchronously via an in-process asyncio queue
@@ -7,7 +7,7 @@ similar existing memories. Runs asynchronously via an in-process asyncio queue
 (when the save comes from a CLI or plugin path without a long-lived worker).
 
 Errors in the check are logged but never propagate to the save caller. The
-save-never-fails invariant is load-bearing.
+save-never-fails invariant is load-bearing — see ADR-004 for rationale.
 
 Public API:
     schedule_contradiction_check(file_path, item, *, sync=False) -> dict | None
@@ -86,7 +86,7 @@ def schedule_contradiction_check(
 
     Never raises. Errors in the check are logged and swallowed — the save
     call path must never fail because of a tier 2a problem. This is the
-    load-bearing invariant.
+    ADR-004 load-bearing invariant.
     """
     if not config.consolidation.write_time.enabled:
         return None

--- a/palinode/core/config.py
+++ b/palinode/core/config.py
@@ -161,7 +161,7 @@ class NightlyConfig:
 
 @dataclass
 class WriteTimeConfig:
-    """Tier 2a: write-time contradiction check on palinode_save.
+    """Tier 2a (ADR-004): write-time contradiction check on palinode_save.
 
     When enabled, every save schedules a background contradiction check
     against similar existing memories. The check runs asynchronously
@@ -291,11 +291,11 @@ class ContextConfig:
 
 @dataclass
 class ScopeConfig:
-    """Layer 1: scope chain for multi-harness, multi-agent, team memory.
+    """ADR-009 Layer 1: scope chain for multi-harness, multi-agent, team memory.
 
     Scopes form an entity-ref hierarchy: org → member → project → harness → agent → session.
     Memories inherit DOWN the chain by default. A session's scope is resolved from
-    env vars and config.
+    env vars and config; see ADR-009 §3.2.
 
     Layer 1 scope (this slice): resolution only — produces a ScopeChain from
     config + env. Later slices wire the chain into store search, the

--- a/palinode/core/defaults.py
+++ b/palinode/core/defaults.py
@@ -1,0 +1,106 @@
+"""
+Palinode cross-surface defaults — single source of truth.
+
+Per ADR-010 (Cross-Surface Parity Contract), every parameter default that
+appears on more than one surface lives here. Surfaces (CLI, MCP, REST API,
+plugin) import from this module rather than baking literals like ``or 0.75``
+into surface-specific code paths.
+
+The ``test_surface_parity`` test asserts that the parity registry's
+``default_key`` references all resolve here, and that no surface uses a
+literal default that contradicts a value defined here.
+
+If a default needs to be configurable, expose it via ``palinode.core.config``
+and re-export here. The contract is "one place to look" — not "one place to
+hard-code."
+"""
+from __future__ import annotations
+
+from palinode.core.config import config
+
+
+# ── Search ───────────────────────────────────────────────────────────────────
+
+#: Default ``limit`` for ``search`` and ``list`` operations.
+SEARCH_LIMIT_DEFAULT: int = 3
+
+#: Default similarity ``threshold`` for ``search`` (server-side).  Driven by
+#: ``config.search.api_threshold`` so deployments can tune via YAML.
+SEARCH_THRESHOLD_DEFAULT: float = config.search.api_threshold
+
+#: Default similarity threshold for ambient/MCP search (typically tighter than
+#: explicit search to keep auto-context noise low).  Driven by config.
+SEARCH_THRESHOLD_MCP: float = config.search.mcp_threshold
+
+
+# ── Triggers ─────────────────────────────────────────────────────────────────
+
+#: Default similarity threshold for prospective-recall triggers.
+TRIGGER_THRESHOLD_DEFAULT: float = 0.75
+
+#: Default cooldown (in hours) between consecutive firings of the same trigger.
+TRIGGER_COOLDOWN_HOURS_DEFAULT: int = 24
+
+
+# ── Diff / history ───────────────────────────────────────────────────────────
+
+#: Default lookback window (in days) for ``diff``.
+DIFF_DAYS_DEFAULT: int = 7
+
+#: Default page size for ``history``.
+HISTORY_LIMIT_DEFAULT: int = 20
+
+
+# ── Save ─────────────────────────────────────────────────────────────────────
+
+#: HTTP request header used to attribute writes to a source surface.
+#:
+#: Per ADR-010, surfaces SHOULD set this header on every API call rather than
+#: putting ``source`` into the body.  The API uses the header value when
+#: ``source`` is not in the body, which lets us keep a stable contract while
+#: each surface maintains its own attribution.
+SAVE_SOURCE_HEADER: str = "X-Palinode-Source"
+
+#: Source attribution sentinel used when the header is absent and no body
+#: ``source`` is supplied.  ``"api"`` matches the FastAPI server's prior
+#: behavior, so this default does not change observable attribution.
+SAVE_SOURCE_API_DEFAULT: str = "api"
+
+
+# ── Session-end dedup (#126) ─────────────────────────────────────────────────
+
+#: Lookback window (in minutes) over which ``session_end`` checks recently
+#: indexed saves for semantic overlap.  60 minutes covers a typical Claude
+#: Code session: long enough to catch /ps → /wrap reformulations of the same
+#: decision, short enough that two genuinely separate sessions on the same
+#: topic don't get conflated.
+SESSION_END_DEDUP_WINDOW_MINUTES: int = 60
+
+#: Cosine-similarity threshold above which a recent save is considered a
+#: duplicate of the new session-end content.  0.85 is conservative — BGE-M3
+#: routinely scores unrelated documents around 0.4-0.6 and near-paraphrases
+#: 0.8-0.95.  Above 0.85 we have high confidence the prior save already
+#: captures the same semantic information.
+SESSION_END_DEDUP_THRESHOLD: float = 0.85
+
+
+# ── Path validation ──────────────────────────────────────────────────────────
+
+#: Allowed memory-file extensions accepted by ``read``/``list`` and the like.
+ALLOWED_MEMORY_EXTENSIONS: tuple[str, ...] = (".md",)
+
+
+__all__ = [
+    "SEARCH_LIMIT_DEFAULT",
+    "SEARCH_THRESHOLD_DEFAULT",
+    "SEARCH_THRESHOLD_MCP",
+    "TRIGGER_THRESHOLD_DEFAULT",
+    "TRIGGER_COOLDOWN_HOURS_DEFAULT",
+    "DIFF_DAYS_DEFAULT",
+    "HISTORY_LIMIT_DEFAULT",
+    "SAVE_SOURCE_HEADER",
+    "SAVE_SOURCE_API_DEFAULT",
+    "SESSION_END_DEDUP_WINDOW_MINUTES",
+    "SESSION_END_DEDUP_THRESHOLD",
+    "ALLOWED_MEMORY_EXTENSIONS",
+]

--- a/palinode/core/parity.py
+++ b/palinode/core/parity.py
@@ -1,0 +1,375 @@
+"""
+Cross-surface parity registry — the canonical-names contract for ADR-010.
+
+Every memory operation that should appear on more than one surface
+(CLI, MCP, REST API, OpenClaw plugin) is enumerated here with one
+canonical name per parameter and one canonical shape (type + required
+flag).  ``tests/test_surface_parity.py`` walks this registry and asserts
+each surface conforms.
+
+When you add a parameter to one surface, add it here first, then
+mirror to the others.  When the four surfaces drift, record the drift
+in ``known_drift`` with the GitHub issue number — the test xfails the
+drift entry until the issue closes.
+
+Admin-only operations (reindex, migrations, doctor, etc.) are explicitly
+exempt from parity by listing them in ``ADMIN_EXEMPT_OPERATIONS``.  The
+contract is "all memory operations are equivalent across surfaces, by
+design"; it is *not* "all operations appear everywhere".
+
+See ``ADR-010-cross-surface-parity-contract.md`` and ``docs/PARITY.md``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+ParamType = Literal["string", "boolean", "array", "integer", "number", "object"]
+Surface = Literal["cli", "mcp", "api", "plugin"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Data model
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CanonicalParam:
+    """One parameter, named and shaped as it should appear on every surface."""
+
+    name: str
+    type: ParamType
+    required: bool = False
+    #: If the default is shared across surfaces, this is the attribute name in
+    #: ``palinode.core.defaults``.  ``None`` means "no default" or "surface-
+    #: specific default that we accept by design".
+    default_key: str | None = None
+    #: Closed set of allowed values, if any.  Surfaces that expose an enum
+    #: must use this exact tuple (order-insensitive).
+    enum: tuple[str, ...] | None = None
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class Operation:
+    """A memory operation with its canonical params and per-surface mapping."""
+
+    name: str
+    canonical_params: tuple[CanonicalParam, ...]
+    cli_command: str | None = None
+    mcp_tool: str | None = None
+    api_endpoint: tuple[str, str] | None = None  # (METHOD, path)
+    plugin_tool: str | None = None
+    #: Surfaces in this set are *not* required to expose the operation.
+    #: Useful when something is intentionally CLI-only (admin) or
+    #: API-only (internal observability) — see ``ADMIN_EXEMPT_OPERATIONS``
+    #: for the global admin carve-out.
+    exempt_surfaces: frozenset[Surface] = field(default_factory=frozenset)
+    #: Known drift, keyed by ``(surface, param_name)``.  Value is the GitHub
+    #: issue number tracking the fix.  The parity test reports these as xfail
+    #: with the issue ref — once the issue closes and the surface is fixed,
+    #: remove the entry and the test enforces.
+    known_drift: dict[tuple[Surface, str], int] = field(default_factory=dict)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Admin carve-out
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+#: Operations that are intentionally NOT subject to cross-surface parity.
+#: They appear on whichever surfaces make operational sense (typically CLI +
+#: API, sometimes only one).  Adding parity for these requires a new ADR.
+ADMIN_EXEMPT_OPERATIONS: frozenset[str] = frozenset(
+    {
+        # Full-database operations (CLI + API only)
+        "reindex",
+        "rebuild-fts",
+        "split-layers",
+        "bootstrap-fact-ids",
+        # One-off importers (CLI + API only)
+        "migrate-openclaw",
+        "migrate-mem0",
+        # Local / operational (CLI only)
+        "doctor",
+        "start",
+        "stop",
+        "config",
+        "banner",
+        # Observability internals (API only)
+        "health",
+        "git-stats",
+        "generate-summaries",
+    }
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Canonical category + type sets
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+#: The canonical ``category`` enum.  Matches the memory-directory names
+#: (plural) — that is the value the ``chunks.category`` column stores
+#: (``palinode/api/server.py:660-668`` and the watcher's directory-basename
+#: derivation).  Surfaces that expose a ``category`` filter MUST use
+#: this exact tuple — ADR-010, finding #161.
+CATEGORIES: tuple[str, ...] = (
+    "people",
+    "projects",
+    "decisions",
+    "insights",
+    "research",
+)
+
+#: The canonical memory ``type`` enum (used by save).  Lives here so
+#: the API can validate ``SaveRequest.type`` server-side instead of
+#: relying on per-surface enum lists.  ADR-010, finding #166.
+MEMORY_TYPES: tuple[str, ...] = (
+    "PersonMemory",
+    "Decision",
+    "ProjectSnapshot",
+    "Insight",
+    "ResearchRef",
+    "ActionItem",
+)
+
+#: The canonical prompt-task enum.  Single source replacing the duplicate
+#: ``"enum"`` keys at ``palinode/mcp.py:624-625``.  ADR-010, finding #162.
+PROMPT_TASKS: tuple[str, ...] = (
+    "compaction",
+    "extraction",
+    "update",
+    "classification",
+    "nightly-consolidation",
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The registry
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+REGISTRY: tuple[Operation, ...] = (
+    # ── status ──────────────────────────────────────────────────────────────
+    Operation(
+        name="status",
+        canonical_params=(),
+        cli_command="status",
+        mcp_tool="palinode_status",
+        api_endpoint=("GET", "/status"),
+    ),
+    # ── list ────────────────────────────────────────────────────────────────
+    Operation(
+        name="list",
+        canonical_params=(
+            CanonicalParam(name="category", type="string", enum=CATEGORIES),
+            CanonicalParam(name="core_only", type="boolean"),
+        ),
+        cli_command="list",
+        mcp_tool="palinode_list",
+        api_endpoint=("GET", "/list"),
+        exempt_surfaces=frozenset({"plugin"}),
+    ),
+    # ── read ────────────────────────────────────────────────────────────────
+    Operation(
+        name="read",
+        canonical_params=(
+            CanonicalParam(name="file_path", type="string", required=True),
+            CanonicalParam(name="meta", type="boolean"),
+        ),
+        cli_command="read",
+        mcp_tool="palinode_read",
+        api_endpoint=("GET", "/read"),
+        exempt_surfaces=frozenset({"plugin"}),
+        known_drift={},
+    ),
+    # ── search ──────────────────────────────────────────────────────────────
+    Operation(
+        name="search",
+        canonical_params=(
+            CanonicalParam(name="query", type="string", required=True),
+            CanonicalParam(
+                name="limit", type="integer", default_key="SEARCH_LIMIT_DEFAULT"
+            ),
+            CanonicalParam(name="category", type="string", enum=CATEGORIES),
+            CanonicalParam(
+                name="threshold",
+                type="number",
+                default_key="SEARCH_THRESHOLD_DEFAULT",
+            ),
+            CanonicalParam(name="since_days", type="integer"),
+            CanonicalParam(name="types", type="array"),
+            CanonicalParam(name="date_after", type="string"),
+            CanonicalParam(name="date_before", type="string"),
+            CanonicalParam(name="include_daily", type="boolean"),
+        ),
+        cli_command="search",
+        mcp_tool="palinode_search",
+        api_endpoint=("POST", "/search"),
+        plugin_tool="palinode_search",
+        known_drift={
+            # #176: plugin TS schema for ``palinode_search`` only exposes
+            # ``query``, ``category``, ``limit`` — the six post-#163 search
+            # filters need to be declared in the plugin's TypeBox schema in
+            # ``plugin/index.ts`` and wired through to the API call.  All
+            # 11 plugin known_drift entries (search × 6 + save × 5) are
+            # tracked together in #176; each closes when the plugin
+            # declares the param and the entry is removed from this dict
+            # (the TS parity test fails otherwise — that's the forcing
+            # function).
+            ("plugin", "threshold"): 176,
+            ("plugin", "since_days"): 176,
+            ("plugin", "types"): 176,
+            ("plugin", "date_after"): 176,
+            ("plugin", "date_before"): 176,
+            ("plugin", "include_daily"): 176,
+        },
+    ),
+    # ── save ────────────────────────────────────────────────────────────────
+    # NOTE on ``ps``: deliberately *not* a canonical parameter.  CLI ``--ps``
+    # and MCP ``ps`` are surface sugar that resolves to ``type=ProjectSnapshot``
+    # locally before hitting the API.  Documented in ``docs/PARITY.md``;
+    # surfaces are free to add the shortcut without parity overhead.  The
+    # plugin currently lacks it (#166 expansion), but adding it is a plugin
+    # courtesy, not a parity obligation.
+    Operation(
+        name="save",
+        canonical_params=(
+            CanonicalParam(name="content", type="string", required=True),
+            CanonicalParam(name="type", type="string", enum=MEMORY_TYPES),
+            CanonicalParam(name="entities", type="array"),
+            CanonicalParam(name="project", type="string"),
+            CanonicalParam(name="metadata", type="object"),
+            CanonicalParam(name="confidence", type="number"),
+            CanonicalParam(name="title", type="string"),
+            CanonicalParam(name="slug", type="string"),
+            CanonicalParam(name="core", type="boolean"),
+            CanonicalParam(name="source", type="string"),
+        ),
+        cli_command="save",
+        mcp_tool="palinode_save",
+        api_endpoint=("POST", "/save"),
+        plugin_tool="palinode_save",
+        known_drift={
+            # #176: plugin TS schema for ``palinode_save`` lacks
+            # ``project`` (originally #159), ``metadata``, ``confidence``,
+            # ``title``, ``source`` (the latter four originally #166).
+            # All five — together with the six search-side gaps — are now
+            # tracked under #176, the dedicated plugin-schema-closure
+            # tracking issue.  ``type`` was in this list during ADR-010's
+            # first wave, but the plugin's ``palinode_save`` TypeBox
+            # schema actually declares ``type``; the TS parity test at
+            # ``plugin/test/parity.test.ts`` surfaced the stale entry, so
+            # it has been removed.  ``title`` and ``source`` are real
+            # plugin gaps surfaced by the same test.
+            ("plugin", "project"): 176,
+            ("plugin", "metadata"): 176,
+            ("plugin", "confidence"): 176,
+            ("plugin", "title"): 176,
+            ("plugin", "source"): 176,
+        },
+    ),
+    # ── consolidate ─────────────────────────────────────────────────────────
+    Operation(
+        name="consolidate",
+        canonical_params=(
+            CanonicalParam(name="dry_run", type="boolean"),
+            CanonicalParam(name="nightly", type="boolean"),
+        ),
+        cli_command="consolidate",
+        mcp_tool="palinode_consolidate",
+        api_endpoint=("POST", "/consolidate"),
+        exempt_surfaces=frozenset({"plugin"}),
+        known_drift={},
+    ),
+    # ── trigger (create) ────────────────────────────────────────────────────
+    # Trigger is multi-action.  We model the most cross-surface-relevant one,
+    # ``create``, and let the others (list, delete) be tested via simpler
+    # presence-only checks (or as separate Operation entries when they have
+    # parameters worth pinning).
+    Operation(
+        name="trigger.create",
+        canonical_params=(
+            CanonicalParam(name="description", type="string", required=True),
+            CanonicalParam(name="memory_file", type="string", required=True),
+            CanonicalParam(name="trigger_id", type="string"),
+            CanonicalParam(
+                name="threshold",
+                type="number",
+                default_key="TRIGGER_THRESHOLD_DEFAULT",
+            ),
+            CanonicalParam(
+                name="cooldown_hours",
+                type="integer",
+                default_key="TRIGGER_COOLDOWN_HOURS_DEFAULT",
+            ),
+        ),
+        cli_command="trigger add",
+        mcp_tool="palinode_trigger",
+        api_endpoint=("POST", "/triggers"),
+        exempt_surfaces=frozenset({"plugin"}),
+        known_drift={},
+    ),
+    # ── rollback ────────────────────────────────────────────────────────────
+    Operation(
+        name="rollback",
+        canonical_params=(
+            CanonicalParam(name="file_path", type="string", required=True),
+            CanonicalParam(name="commit", type="string"),
+            CanonicalParam(name="dry_run", type="boolean"),
+        ),
+        cli_command="rollback",
+        mcp_tool="palinode_rollback",
+        api_endpoint=("POST", "/rollback"),
+        exempt_surfaces=frozenset({"plugin"}),
+        known_drift={},
+    ),
+    # ── blame ───────────────────────────────────────────────────────────────
+    Operation(
+        name="blame",
+        canonical_params=(
+            CanonicalParam(name="file_path", type="string", required=True),
+            CanonicalParam(name="search", type="string"),
+        ),
+        cli_command="blame",
+        mcp_tool="palinode_blame",
+        api_endpoint=("GET", "/blame/{file_path:path}"),
+        exempt_surfaces=frozenset({"plugin"}),
+        known_drift={},
+    ),
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def by_name(op_name: str) -> Operation:
+    """Look up an operation by name.  Raises ``KeyError`` if missing."""
+    for op in REGISTRY:
+        if op.name == op_name:
+            return op
+    raise KeyError(op_name)
+
+
+def required_surfaces(op: Operation) -> frozenset[Surface]:
+    """Return the surfaces this operation must appear on (i.e. not exempt)."""
+    all_surfaces: frozenset[Surface] = frozenset({"cli", "mcp", "api", "plugin"})
+    return all_surfaces - op.exempt_surfaces
+
+
+__all__ = [
+    "ADMIN_EXEMPT_OPERATIONS",
+    "CATEGORIES",
+    "CanonicalParam",
+    "MEMORY_TYPES",
+    "Operation",
+    "PROMPT_TASKS",
+    "ParamType",
+    "REGISTRY",
+    "Surface",
+    "by_name",
+    "required_surfaces",
+]

--- a/palinode/core/scope.py
+++ b/palinode/core/scope.py
@@ -1,9 +1,11 @@
-"""Scope chain resolution (Layer 1 of scoped memory).
+"""ADR-009 Layer 1: scope chain resolution.
 
 Build a ScopeChain from config + env + caller-supplied project/session, to be
-consumed by scope-filtered search and the context prime endpoint. This module
-is pure resolution — no I/O, no DB, no filtering. Isolating it here keeps
-subsequent layers easy to test.
+consumed by scope-filtered search (Slice 3) and the context prime endpoint
+(Slice 4). This module is pure resolution — no I/O, no DB, no filtering.
+Isolating it here keeps subsequent slices easy to test.
+
+See ADR-009 §3.1-3.2 for the hierarchy and auto-detection rules.
 """
 from __future__ import annotations
 
@@ -53,8 +55,8 @@ def resolve_scope_chain(
     """Resolve the scope chain for the current session.
 
     ``project`` should be the caller-resolved project entity name (typically
-    supplied by the ambient-context detection). Pass ``None`` when the caller
-    has no project signal.
+    supplied by the ADR-008 ambient-context detection). Pass ``None`` in
+    pre-ADR-008 setups or when the caller has no project signal.
 
     ``session_id`` is the caller-generated session identifier. Pass ``None``
     when session-level scoping is not in use.

--- a/palinode/core/store.py
+++ b/palinode/core/store.py
@@ -15,9 +15,10 @@ import sqlite3
 import sqlite_vec
 import json
 import os
+import struct
 import hashlib
 from typing import Any, Sequence
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from palinode.core.config import config
 
 # ── Security Scanning ────────────────────────────────────────────────────────
@@ -352,7 +353,7 @@ def search(query_embedding: list[float], category: str | None = None,
         top_k (int): Maximum number of results to return.
         threshold (float): Minimum cosine similarity score (0.0-1.0).
         context_entities (list[str] | None): Entity refs (e.g. ["project/palinode"])
-            for ambient context boost. Matching results get score * config.context.boost.
+            for ADR-008 ambient context boost. Matching results get score * config.context.boost.
         include_daily (bool): If True, skip the daily/ penalty (search daily notes at full rank).
 
     Returns:
@@ -424,7 +425,7 @@ def search(query_embedding: list[float], category: str | None = None,
 
     db.close()
 
-    # Ambient context boost (same logic as search_hybrid)
+    # ADR-008: Ambient context boost (same logic as search_hybrid)
     if context_entities and config.context.enabled and config.context.boost != 1.0:
         context_files: set[str] = set()
         for entity in context_entities:
@@ -671,6 +672,97 @@ def list_recent(
     return results
 
 
+def recent_save_embeddings(
+    window_minutes: int,
+    now: datetime | None = None,
+    fetch_limit: int = 200,
+) -> list[tuple[str, list[float]]]:
+    """Return embeddings of chunks indexed within the last ``window_minutes``.
+
+    Backs the session-end semantic-dedup check (#126).  Joins ``chunks_vec``
+    against ``chunks`` so we can pull the embedding alongside a useful slug
+    (the ``id`` column doubles as a human-readable identifier the API uses
+    when reporting which prior save matched).
+
+    "Recent" is determined by file mtime, not by ``chunks.created_at``: the
+    latter is sourced from frontmatter that's known to be inconsistent across
+    write paths (some surfaces write local time with a ``Z`` suffix; the
+    watcher reads ``created`` rather than ``created_at`` and so commonly
+    leaves it empty).  File mtime is a reliable wall-clock signal for "this
+    file was just written," which is what dedup actually needs.
+
+    To bound the I/O, we order by ``rowid DESC`` (newer chunks have higher
+    rowids) and inspect at most ``fetch_limit`` rows.  In a typical
+    palinode deployment this comfortably covers a 60-minute window.
+
+    Files under ``daily/`` are excluded — they're append-only logs that
+    always overlap recent saves by construction; treating them as dedup
+    candidates would suppress every session-end after the first.
+
+    Args:
+        window_minutes: Lookback window.  Negative or zero values yield an
+            empty list (callers can disable dedup by passing 0).
+        now: Override for the current time, primarily for tests.  Defaults
+            to wall-clock UTC.
+        fetch_limit: Max number of rows to inspect (rowid-ordered).
+
+    Returns:
+        List of ``(slug, embedding)`` tuples for chunks whose source file
+        mtime is within the window.  Order is most-recent-first.  Empty
+        list on any DB error or when the window is non-positive.
+    """
+    if window_minutes <= 0:
+        return []
+
+    cutoff_ts = ((now or _utc_now()) - timedelta(minutes=window_minutes)).timestamp()
+
+    try:
+        db = get_db()
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            SELECT c.id, c.file_path, v.embedding
+            FROM chunks c
+            JOIN chunks_vec v ON v.id = c.id
+            ORDER BY c.rowid DESC
+            LIMIT ?
+            """,
+            (fetch_limit,),
+        )
+        rows = cursor.fetchall()
+        db.close()
+    except sqlite3.Error:
+        return []
+
+    out: list[tuple[str, list[float]]] = []
+    for row in rows:
+        file_path = row["file_path"]
+        if _is_daily_file(file_path):
+            continue
+        try:
+            mtime = os.path.getmtime(file_path)
+        except OSError:
+            # File gone (deleted, renamed) — skip; can't confirm freshness
+            continue
+        if mtime < cutoff_ts:
+            continue
+        raw = row["embedding"]
+        try:
+            if isinstance(raw, (bytes, bytearray)):
+                # sqlite-vec stores embeddings as packed little-endian float32
+                count = len(raw) // 4
+                vec = list(struct.unpack(f"{count}f", raw))
+            elif isinstance(raw, str):
+                vec = json.loads(raw)
+            else:
+                vec = list(raw)
+        except (ValueError, struct.error, TypeError):
+            continue
+        if vec:
+            out.append((row["id"], vec))
+    return out
+
+
 def search_hybrid(
     query_text: str,
     query_embedding: list[float],
@@ -770,7 +862,7 @@ def search_hybrid(
         for key in sorted_keys:
             result_map[key]["score"] = rrf_scores[key] / max_score
 
-    # Ambient context boost: boost results matching caller's project context
+    # Ambient context boost (ADR-008): boost results matching caller's project context
     if context_entities and config.context.enabled and config.context.boost != 1.0:
         context_files: set[str] = set()
         for entity in context_entities:

--- a/palinode/indexer/watcher.py
+++ b/palinode/indexer/watcher.py
@@ -162,7 +162,10 @@ class PalinodeHandler(FileSystemEventHandler):
                 "category": category,
                 "content": sec["content"],
                 "metadata": metadata,
-                "created_at": metadata.get("created", ""),
+                # #191: producers (save_api, consolidation, ingest, openclaw,
+                # mem0_generate) write the key as ``created_at`` — historical
+                # ``"created"`` read here always returned ``""``.
+                "created_at": metadata.get("created_at", ""),
                 "last_updated": metadata.get("last_updated", ""),
                 "embedding": emb
             })

--- a/palinode/ingest/pipeline.py
+++ b/palinode/ingest/pipeline.py
@@ -16,6 +16,7 @@ import re
 import time
 import logging
 import subprocess
+from datetime import UTC, datetime
 from pathlib import Path
 
 import httpx
@@ -317,7 +318,9 @@ def write_research_file(
         "source_type": file_type,
         "date": today,
         "tags": [],
-        "last_updated": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        # #193: timezone-aware UTC ISO-8601. Previously used
+        # ``time.strftime("...Z")`` which emits local time stamped as UTC.
+        "last_updated": datetime.now(UTC).isoformat(),
     }
 
     doc = f"---\n{yaml.dump(fm, default_flow_style=False)}---\n\n# {name}\n\n{content}\n"

--- a/palinode/mcp.py
+++ b/palinode/mcp.py
@@ -71,7 +71,7 @@ def _coerce_str_array(value: Any) -> Any:
 
 
 def _resolve_context() -> list[str] | None:
-    """Resolve ambient project context from environment.
+    """Resolve ambient project context from environment (ADR-008).
 
     Resolution order:
     1. PALINODE_PROJECT env var (explicit entity ref, e.g. "project/palinode")
@@ -113,27 +113,36 @@ def _api_url(path: str) -> str:
     return f"http://{host}:{port}{path}"
 
 
+# ADR-010 / #167: every MCP request carries surface attribution as a
+# header.  The API uses this when the body doesn't explicitly set `source`,
+# giving consistent provenance across the four surfaces without each tool
+# dispatcher having to thread a default through every call site.
+from palinode.core.defaults import SAVE_SOURCE_HEADER as _SOURCE_HEADER
+
+_DEFAULT_HEADERS = {_SOURCE_HEADER: "mcp"}
+
+
 async def _get(path: str, params: dict | None = None, timeout: float = 30.0) -> httpx.Response:
     """Async HTTP GET to the API server."""
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(headers=_DEFAULT_HEADERS) as client:
         return await client.get(_api_url(path), params=params, timeout=timeout)
 
 
 async def _post(path: str, json: dict | None = None, timeout: float = 30.0) -> httpx.Response:
     """Async HTTP POST to the API server."""
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(headers=_DEFAULT_HEADERS) as client:
         return await client.post(_api_url(path), json=json, timeout=timeout)
 
 
 async def _post_params(path: str, params: dict | None = None, timeout: float = 30.0) -> httpx.Response:
     """Async HTTP POST with query params (no JSON body) to the API server."""
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(headers=_DEFAULT_HEADERS) as client:
         return await client.post(_api_url(path), params=params, timeout=timeout)
 
 
 async def _delete(path: str, timeout: float = 30.0) -> httpx.Response:
     """Async HTTP DELETE to the API server."""
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(headers=_DEFAULT_HEADERS) as client:
         return await client.delete(_api_url(path), timeout=timeout)
 
 
@@ -227,6 +236,15 @@ async def list_tools() -> list[types.Tool]:
                         "type": "string",
                         "description": "Relative path to the memory file (e.g., 'people/alice.md', 'projects/palinode-status.md')",
                     },
+                    "meta": {
+                        "type": "boolean",
+                        "description": (
+                            "If true, the response includes parsed frontmatter "
+                            "alongside the body.  Default false (body only) to "
+                            "match prior behavior."
+                        ),
+                        "default": False,
+                    },
                 },
                 "required": ["file_path"],
             },
@@ -251,8 +269,8 @@ async def list_tools() -> list[types.Tool]:
                     },
                     "category": {
                         "type": "string",
-                        "description": "Filter by category: person, project, decision, insight, research",
-                        "enum": ["person", "project", "decision", "insight", "research"],
+                        "description": "Filter by category (memory directory name): people, projects, decisions, insights, research",
+                        "enum": ["people", "projects", "decisions", "insights", "research"],
                     },
                     "limit": {
                         "type": "integer",
@@ -271,6 +289,37 @@ async def list_tools() -> list[types.Tool]:
                         "type": "boolean",
                         "description": "Include daily session notes at full rank (default: false, daily/ files are penalized)",
                         "default": False,
+                    },
+                    "since_days": {
+                        "type": "integer",
+                        "description": (
+                            "Only return memories created/updated in the last "
+                            "N days.  Equivalent to setting `date_after` to "
+                            "now-N days; the API derives one from the other."
+                        ),
+                    },
+                    "types": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "PersonMemory",
+                                "Decision",
+                                "ProjectSnapshot",
+                                "Insight",
+                                "ResearchRef",
+                                "ActionItem",
+                            ],
+                        },
+                        "description": "Filter by memory type (matches frontmatter `type`).",
+                    },
+                    "threshold": {
+                        "type": "number",
+                        "description": (
+                            "Override similarity threshold (0.0–1.0).  Higher "
+                            "= stricter.  Defaults to MCP-tuned value from "
+                            "config when omitted."
+                        ),
                     },
                 },
                 "required": ["query"],
@@ -316,6 +365,39 @@ async def list_tools() -> list[types.Tool]:
                         "type": "array",
                         "items": {"type": "string"},
                         "description": "Related entity refs e.g. ['person/alice', 'project/alpha']",
+                    },
+                    "project": {
+                        "type": "string",
+                        "description": (
+                            "Project slug shorthand — e.g. 'palinode' becomes "
+                            "entity 'project/palinode'.  Pairs with "
+                            "`palinode_session_end`'s `project` field for "
+                            "consistent project tagging across save and "
+                            "session-end."
+                        ),
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": (
+                            "Optional human-readable title.  Stored in "
+                            "frontmatter and used in list/search displays."
+                        ),
+                    },
+                    "metadata": {
+                        "type": "object",
+                        "description": (
+                            "Arbitrary additional frontmatter fields to merge "
+                            "into the saved memory.  Keys override the "
+                            "auto-generated frontmatter; use sparingly."
+                        ),
+                    },
+                    "confidence": {
+                        "type": "number",
+                        "description": (
+                            "Caller's confidence in this memory's accuracy "
+                            "(0.0–1.0).  Stored as frontmatter; surfaces in "
+                            "downstream consolidation passes."
+                        ),
                     },
                     "source": {
                         "type": "string",
@@ -408,10 +490,31 @@ async def list_tools() -> list[types.Tool]:
         ),
         types.Tool(
             name="palinode_consolidate",
-            description="Run a manual knowledge consolidation pass.",
+            description=(
+                "Run a manual knowledge consolidation pass.  Set `dry_run=true` "
+                "to preview the proposed operations without applying them."
+            ),
             inputSchema={
                 "type": "object",
-                "properties": {},
+                "properties": {
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": (
+                            "Preview operations without writing changes.  "
+                            "Recommended when invoking from MCP — the tool is "
+                            "annotated destructive."
+                        ),
+                        "default": False,
+                    },
+                    "nightly": {
+                        "type": "boolean",
+                        "description": (
+                            "Run the nightly compaction prompt instead of the "
+                            "default write-time pass."
+                        ),
+                        "default": False,
+                    },
+                },
             },
             annotations=types.ToolAnnotations(
                 title="Run Consolidation",
@@ -453,16 +556,23 @@ async def list_tools() -> list[types.Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "file": {
+                    "file_path": {
                         "type": "string",
                         "description": "Memory file path (e.g., 'projects/my-app.md')",
+                    },
+                    "file": {
+                        "type": "string",
+                        "description": (
+                            "Deprecated alias for `file_path` (ADR-010 / #164). "
+                            "Will be removed in a future release."
+                        ),
                     },
                     "search": {
                         "type": "string",
                         "description": "Optional: filter to lines containing this text",
                     },
                 },
-                "required": ["file"],
+                # `file_path` or `file` (legacy) — validated in the dispatcher.
             },
             annotations=types.ToolAnnotations(
                 title="Blame / Provenance",
@@ -478,9 +588,16 @@ async def list_tools() -> list[types.Tool]:
             inputSchema={
                 "type": "object",
                 "properties": {
-                    "file": {
+                    "file_path": {
                         "type": "string",
                         "description": "Memory file path to rollback",
+                    },
+                    "file": {
+                        "type": "string",
+                        "description": (
+                            "Deprecated alias for `file_path` (ADR-010 / #164). "
+                            "Will be removed in a future release."
+                        ),
                     },
                     "commit": {
                         "type": "string",
@@ -492,7 +609,7 @@ async def list_tools() -> list[types.Tool]:
                         "default": True,
                     },
                 },
-                "required": ["file"],
+                # `file_path` or `file` (legacy) — validated in the dispatcher.
             },
             annotations=types.ToolAnnotations(
                 title="Rollback File",
@@ -534,6 +651,21 @@ async def list_tools() -> list[types.Tool]:
                     "trigger_id": {
                         "type": "string",
                         "description": "For 'delete' or 'create': Custom UUID or ID to delete/create",
+                    },
+                    "threshold": {
+                        "type": "number",
+                        "description": (
+                            "For 'create': Similarity threshold (0.0–1.0).  "
+                            "Higher = stricter match required to fire.  "
+                            "Default 0.75."
+                        ),
+                    },
+                    "cooldown_hours": {
+                        "type": "integer",
+                        "description": (
+                            "For 'create': Hours to wait between consecutive "
+                            "firings of the same trigger.  Default 24."
+                        ),
                     },
                 },
                 "required": ["action"],
@@ -622,7 +754,6 @@ async def list_tools() -> list[types.Tool]:
                         "type": "string",
                         "description": "For 'list': filter by task type",
                         "enum": ["compaction", "extraction", "update", "classification", "nightly-consolidation"],
-                        "enum": ["compaction", "extraction", "update", "classification"],
                     },
                 },
                 "required": ["action"],
@@ -680,10 +811,26 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[types.Tex
 
         # ── read ──────────────────────────────────────────────────────────
         elif name == "palinode_read":
-            resp = await _get("/read", params={"file_path": arguments["file_path"], "meta": "true"})
+            # ADR-010 / #168: honor caller's `meta` request.  We always fetch
+            # with meta=true (cheap; parser already runs) but only render
+            # frontmatter when the caller asked for it.
+            include_meta = bool(arguments.get("meta", False))
+            resp = await _get(
+                "/read",
+                params={"file_path": arguments["file_path"], "meta": "true"},
+            )
             if resp.status_code != 200:
                 return _text(f"Error reading file: {resp.text}")
-            return _text(resp.json()["content"])
+            data = resp.json()
+            content = data.get("content", "")
+            if include_meta:
+                fm = data.get("frontmatter") or {}
+                # Render as YAML-ish frontmatter + body so downstream consumers
+                # can re-parse if they want.  Keep it simple: the file already
+                # has the same structure on disk.
+                fm_lines = "\n".join(f"{k}: {v!r}" for k, v in fm.items())
+                return _text(f"---\n{fm_lines}\n---\n{content}")
+            return _text(content)
 
         # ── search ────────────────────────────────────────────────────────
         elif name == "palinode_search":
@@ -698,9 +845,18 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[types.Tex
                 body["date_before"] = arguments["date_before"]
             if arguments.get("include_daily"):
                 body["include_daily"] = True
-            # Use MCP threshold, not API default
-            body["threshold"] = config.search.mcp_threshold
-            # ambient context boost
+            if arguments.get("since_days") is not None:
+                body["since_days"] = int(arguments["since_days"])
+            if arguments.get("types"):
+                body["types"] = _coerce_str_array(arguments["types"])
+            # ADR-010 / #163: caller-supplied threshold wins; otherwise use
+            # the MCP-tuned default (typically tighter than the API default
+            # to keep auto-context noise low).
+            if arguments.get("threshold") is not None:
+                body["threshold"] = float(arguments["threshold"])
+            else:
+                body["threshold"] = config.search.mcp_threshold
+            # ADR-008: ambient context boost
             context = _resolve_context()
             if context:
                 body["context"] = context
@@ -721,17 +877,29 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[types.Tex
             except ValueError as e:
                 return _text(f"Error: {e}")
 
-            body = {
+            body: dict[str, Any] = {
                 "content": arguments["content"],
                 "type": resolved_type,
-                "source": arguments.get("source", "mcp"),
             }
+            # ADR-010 / #167: only set body source when caller explicitly
+            # supplied one.  Otherwise the X-Palinode-Source header (set on
+            # every MCP request) carries attribution to the API.
+            if arguments.get("source"):
+                body["source"] = arguments["source"]
             if arguments.get("slug"):
                 body["slug"] = arguments["slug"]
             if arguments.get("core") is not None:
                 body["core"] = arguments["core"]
             if arguments.get("entities"):
                 body["entities"] = _coerce_str_array(arguments["entities"])
+            if arguments.get("project"):
+                body["project"] = arguments["project"]
+            if arguments.get("title"):
+                body["title"] = arguments["title"]
+            if arguments.get("metadata") is not None:
+                body["metadata"] = arguments["metadata"]
+            if arguments.get("confidence") is not None:
+                body["confidence"] = float(arguments["confidence"])
 
             resp = await _post("/save", json=body)
             if resp.status_code != 200:
@@ -788,7 +956,12 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[types.Tex
 
         # ── consolidate ───────────────────────────────────────────────────
         elif name == "palinode_consolidate":
-            resp = await _post("/consolidate", timeout=300.0)
+            body: dict[str, Any] = {}
+            if arguments.get("dry_run"):
+                body["dry_run"] = True
+            if arguments.get("nightly"):
+                body["nightly"] = True
+            resp = await _post("/consolidate", json=body, timeout=300.0)
             if resp.status_code != 200:
                 return _text(f"Consolidation failed: {resp.text}")
             return _text(json.dumps(resp.json(), indent=2))
@@ -827,7 +1000,11 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[types.Tex
 
         # ── blame ─────────────────────────────────────────────────────────
         elif name == "palinode_blame":
-            file_path = arguments["file"]
+            # ADR-010 / #164: prefer canonical `file_path`; accept legacy
+            # `file` for one release.
+            file_path = arguments.get("file_path") or arguments.get("file")
+            if not file_path:
+                return _text("Error: file_path is required")
             params: dict[str, str] = {}
             if arguments.get("search"):
                 params["search"] = arguments["search"]
@@ -838,7 +1015,12 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[types.Tex
 
         # ── rollback ──────────────────────────────────────────────────────
         elif name == "palinode_rollback":
-            params: dict[str, str] = {"file_path": arguments["file"]}
+            # ADR-010 / #164: prefer canonical `file_path`; accept legacy
+            # `file` for one release.
+            file_path = arguments.get("file_path") or arguments.get("file")
+            if not file_path:
+                return _text("Error: file_path is required")
+            params: dict[str, str] = {"file_path": file_path}
             if arguments.get("commit"):
                 params["commit"] = arguments["commit"]
             params["dry_run"] = str(arguments.get("dry_run", True)).lower()
@@ -884,6 +1066,10 @@ async def _dispatch_tool(name: str, arguments: dict[str, Any]) -> list[types.Tex
                 }
                 if arguments.get("trigger_id"):
                     body["trigger_id"] = arguments["trigger_id"]
+                if arguments.get("threshold") is not None:
+                    body["threshold"] = arguments["threshold"]
+                if arguments.get("cooldown_hours") is not None:
+                    body["cooldown_hours"] = arguments["cooldown_hours"]
                 resp = await _post("/triggers", json=body)
                 if resp.status_code != 200:
                     return _text(f"Error: {resp.text}")

--- a/palinode/migration/mem0_classify.py
+++ b/palinode/migration/mem0_classify.py
@@ -1,0 +1,248 @@
+"""
+Mem0 Memory Classifier
+
+Takes raw Mem0 export JSON and produces classified, deduplicated,
+grouped memories ready for file generation.
+
+Uses Qwen 2.5 72B on Mac Studio for batch classification.
+This is a one-time irreversible triage — use the best model available.
+
+Usage:
+    python -m palinode.migration.mem0_classify
+
+Input:
+    $PALINODE_DIR/migration/mem0_export.json
+
+Output:
+    $PALINODE_DIR/migration/mem0_classified.json
+
+LLM Config:
+    URL: http://localhost:8080/v1
+    Model: any local model with sufficient context (Qwen 2.5 72B or similar)
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import logging
+from collections import defaultdict
+from datetime import datetime
+
+import httpx
+
+from palinode.core.config import config
+from palinode.core.hashing import stable_md5_hexdigest
+
+logger = logging.getLogger("palinode.migration.mem0_classify")
+
+# ── Deduplication ─────────────────────────────────────────────────────────────
+
+def deduplicate(memories: list[dict]) -> list[dict]:
+    """Remove exact duplicates (by hash) and near-duplicates (by content similarity).
+
+    Strategy:
+    1. Exact dedup: same hash field → keep newest
+    2. Content dedup: normalize whitespace/case → same normalized text → keep newest
+    3. Substring dedup: if memory A is a substring of memory B → drop A, keep B
+
+    Args:
+        memories: Raw exported memories.
+
+    Returns:
+        Deduplicated list (expected ~40-60% reduction).
+    """
+    # Phase 1: Hash dedup
+    by_hash = {}
+    for m in memories:
+        h = m.get("hash", "")
+        if not h:
+            h = stable_md5_hexdigest(m["content"])
+        if h in by_hash:
+            # Keep the newer one
+            if m.get("created_at", "") > by_hash[h].get("created_at", ""):
+                by_hash[h] = m
+        else:
+            by_hash[h] = m
+
+    deduped = list(by_hash.values())
+    logger.info(f"Hash dedup: {len(memories)} → {len(deduped)}")
+
+    # Phase 2: Normalized content dedup
+    by_normalized = {}
+    for m in deduped:
+        norm = re.sub(r'\s+', ' ', m["content"].lower().strip())
+        if norm in by_normalized:
+            if m.get("created_at", "") > by_normalized[norm].get("created_at", ""):
+                by_normalized[norm] = m
+        else:
+            by_normalized[norm] = m
+
+    deduped = list(by_normalized.values())
+    logger.info(f"Content dedup: → {len(deduped)}")
+
+    # Phase 3: Substring dedup (drop short memories that are contained in longer ones)
+    # Sort by length descending so we check shorter against longer
+    sorted_mems = sorted(deduped, key=lambda m: len(m["content"]), reverse=True)
+    keep = []
+    kept_content = []
+    for m in sorted_mems:
+        norm = re.sub(r'\s+', ' ', m["content"].lower().strip())
+        is_substring = any(norm in existing for existing in kept_content)
+        if not is_substring:
+            keep.append(m)
+            kept_content.append(norm)
+
+    logger.info(f"Substring dedup: → {len(keep)}")
+    return keep
+
+
+# ── Classification ────────────────────────────────────────────────────────────
+
+# Classification prompt for the LLM
+CLASSIFY_SYSTEM_PROMPT = """You are a memory classifier for an AI agent's persistent memory system.
+
+Given a batch of raw memory snippets, classify each one:
+
+1. **type**: One of: PersonMemory, Decision, ProjectSnapshot, Insight, ActionItem, Config, Skip
+   - PersonMemory: facts about a person (preferences, relationships, contact info)
+   - Decision: a choice that was made with rationale
+   - ProjectSnapshot: current state of a project or milestone
+   - Insight: a lesson learned or recurring pattern
+   - ActionItem: something that needs to be done
+   - Config: system configuration or technical setup detail
+   - Skip: not worth keeping (too vague, trivially obvious, or stale operational detail)
+
+2. **entities**: Array of entity references, e.g. ["person/alice", "project/example"]
+   Known entities: person/alice, person/bob, person/carol, project/example, project/palinode, project/other-app, project/infrastructure
+
+3. **group**: A short slug for grouping related memories into the same file.
+   Related memories about the same topic should share a group slug.
+   Examples: "example-feature-shipping", "alice-preferences", "infrastructure-vllm"
+
+Return a JSON array with one object per memory:
+```json
+[
+  {"index": 0, "type": "ProjectSnapshot", "entities": ["project/example"], "group": "example-milestones"},
+  {"index": 1, "type": "Skip", "entities": [], "group": ""},
+  ...
+]
+```
+
+Mark as "Skip" if the memory is:
+- Too vague to be useful ("something was discussed")
+- A transient operational detail ("restarting the server")
+- Already captured better elsewhere
+- Configuration that's likely stale
+
+Be aggressive with Skip — quality over quantity. We want ~50-100 files, not 4,000."""
+
+
+def classify_batch(memories: list[dict], batch_size: int = 20) -> list[dict]:
+    """Classify memories in batches using the LLM.
+
+    Args:
+        memories: Deduplicated memories to classify.
+        batch_size: How many memories to classify per LLM call.
+
+    Returns:
+        Memories with added 'type', 'entities', 'group' fields.
+    """
+    classified = []
+
+    for i in range(0, len(memories), batch_size):
+        batch = memories[i:i + batch_size]
+        batch_text = "\n".join(
+            f"[{j}] ({m.get('source_agent', '?')}, {m.get('created_at', '?')[:10]}) {m['content'][:300]}"
+            for j, m in enumerate(batch)
+        )
+
+        # Use Qwen 72B on Mac Studio for classification (best available model)
+        # This is a one-time migration — quality > speed
+        CLASSIFY_LLM_URL = os.environ.get(
+            "PALINODE_CLASSIFY_LLM_URL",
+            "http://localhost:8080"
+        )
+        CLASSIFY_LLM_MODEL = os.environ.get(
+            "PALINODE_CLASSIFY_LLM_MODEL",
+            "/path/to/models/qwen25-72b-abliterated-mlx"
+        )
+
+        try:
+            resp = httpx.post(
+                f"{CLASSIFY_LLM_URL}/v1/chat/completions",
+                json={
+                    "model": CLASSIFY_LLM_MODEL,
+                    "messages": [
+                        {"role": "system", "content": CLASSIFY_SYSTEM_PROMPT},
+                        {"role": "user", "content": f"Classify these {len(batch)} memories:\n\n{batch_text}"},
+                    ],
+                    "temperature": 0.1,
+                    "max_tokens": 2000,
+                },
+                timeout=600.0,  # Qwen 72B on MLX is slow — 5min per batch
+            )
+            resp.raise_for_status()
+            result_text = resp.json()["choices"][0]["message"]["content"]
+
+            # Parse JSON from response
+            json_match = re.search(r"\[[\s\S]*\]", result_text)
+            if json_match:
+                classifications = json.loads(json_match.group())
+                for c in classifications:
+                    idx = c.get("index", 0)
+                    if 0 <= idx < len(batch):
+                        batch[idx]["type"] = c.get("type", "Skip")
+                        batch[idx]["entities"] = c.get("entities", [])
+                        batch[idx]["group"] = c.get("group", "")
+
+        except Exception as e:
+            logger.error(f"Classification batch {i}-{i+len(batch)} failed: {e}")
+            # Mark failed batch as unclassified
+            for m in batch:
+                m.setdefault("type", "Skip")
+                m.setdefault("entities", [])
+                m.setdefault("group", "unclassified")
+
+        classified.extend(batch)
+        logger.info(f"Classified {min(i + batch_size, len(memories))}/{len(memories)}")
+
+    return classified
+
+
+def run_classification() -> str:
+    """Full pipeline: load export → deduplicate → classify → save.
+
+    Returns:
+        Path to classified output JSON.
+    """
+    export_path = os.path.join(config.memory_dir, "migration", "mem0_export.json")
+    output_path = os.path.join(config.memory_dir, "migration", "mem0_classified.json")
+
+    with open(export_path) as f:
+        memories = json.load(f)
+
+    logger.info(f"Loaded {len(memories)} raw memories")
+
+    # Deduplicate
+    deduped = deduplicate(memories)
+
+    # Classify
+    classified = classify_batch(deduped)
+
+    # Stats
+    type_counts = defaultdict(int)
+    for m in classified:
+        type_counts[m.get("type", "Unknown")] += 1
+    logger.info(f"Classification stats: {dict(type_counts)}")
+
+    with open(output_path, "w") as f:
+        json.dump(classified, f, indent=2, default=str)
+
+    logger.info(f"Classified output → {output_path}")
+    return output_path
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    run_classification()

--- a/palinode/migration/mem0_export.py
+++ b/palinode/migration/mem0_export.py
@@ -1,0 +1,108 @@
+"""
+Mem0 → JSON Exporter
+
+Scrolls through all Qdrant collections and exports memories to a
+single JSON file for offline processing. No transformation — just export.
+
+Usage:
+    python -m palinode.migration.mem0_export
+
+Output:
+    $PALINODE_DIR/migration/mem0_export.json
+"""
+from __future__ import annotations
+
+import json
+import os
+import logging
+from datetime import datetime
+
+import httpx
+
+from palinode.core.config import config
+
+logger = logging.getLogger("palinode.migration.mem0_export")
+
+QDRANT_URL = "http://localhost:6333"
+COLLECTIONS = ["mem0_attractor", "mem0_governor", "mem0_gradient"]
+BATCH_SIZE = 100  # Qdrant scroll batch size
+
+
+def export_all() -> str:
+    """Export all Mem0 memories from Qdrant to JSON.
+
+    Returns:
+        Path to the exported JSON file.
+    """
+    output_dir = os.path.join(config.memory_dir, "migration")
+    os.makedirs(output_dir, exist_ok=True)
+    output_path = os.path.join(output_dir, "mem0_export.json")
+
+    all_memories = []
+
+    for collection in COLLECTIONS:
+        logger.info(f"Exporting {collection}...")
+        memories = _scroll_collection(collection)
+        logger.info(f"  Exported {len(memories)} memories from {collection}")
+        all_memories.extend(memories)
+
+    # Sort by date
+    all_memories.sort(key=lambda m: m.get("created_at", ""))
+
+    with open(output_path, "w") as f:
+        json.dump(all_memories, f, indent=2, default=str)
+
+    logger.info(f"Total: {len(all_memories)} memories → {output_path}")
+    return output_path
+
+
+def _scroll_collection(collection: str) -> list[dict]:
+    """Scroll through a Qdrant collection and extract all payloads."""
+    memories = []
+    offset = None
+
+    while True:
+        body = {
+            "limit": BATCH_SIZE,
+            "with_payload": True,
+            "with_vector": False,
+        }
+        if offset:
+            body["offset"] = offset
+
+        resp = httpx.post(
+            f"{QDRANT_URL}/collections/{collection}/points/scroll",
+            json=body,
+            timeout=30.0,
+        )
+        resp.raise_for_status()
+        result = resp.json().get("result", {})
+        points = result.get("points", [])
+
+        if not points:
+            break
+
+        for p in points:
+            payload = p.get("payload", {})
+            memories.append({
+                "id": str(p["id"]),
+                "content": payload.get("data", payload.get("memory", "")),
+                "source_agent": payload.get("source_agent", collection.replace("mem0_", "")),
+                "source_collection": collection,
+                "created_at": payload.get("createdAt", ""),
+                "hash": payload.get("hash", ""),
+                "session_type": payload.get("session_type", ""),
+                "user_id": payload.get("userId", "clawd"),
+            })
+
+        offset = result.get("next_page_offset")
+        if not offset:
+            break
+
+    return memories
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    path = export_all()
+    print(f"Exported to: {path}")

--- a/palinode/migration/mem0_generate.py
+++ b/palinode/migration/mem0_generate.py
@@ -1,0 +1,158 @@
+"""
+Mem0 → Palinode File Generator
+
+Takes classified memories and generates typed markdown files,
+merging related memories into coherent documents.
+
+Usage:
+    python -m palinode.migration.mem0_generate
+
+Input:
+    $PALINODE_DIR/migration/mem0_classified.json
+
+Output:
+    Markdown files in $PALINODE_DIR/{category}/
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+import logging
+from collections import defaultdict
+from datetime import UTC, datetime
+
+import yaml
+
+from palinode.core.config import config
+
+logger = logging.getLogger("palinode.migration.mem0_generate")
+
+
+# Category mapping
+TYPE_TO_CATEGORY = {
+    "PersonMemory": "people",
+    "Decision": "decisions",
+    "ProjectSnapshot": "projects",
+    "Insight": "insights",
+    "ActionItem": "inbox",
+    "Config": "decisions",  # Config decisions go to decisions/
+}
+
+
+def generate_files() -> dict:
+    """Generate Palinode markdown files from classified Mem0 memories.
+
+    Groups memories by their 'group' slug, then generates one
+    markdown file per group. Related memories within a group are
+    merged into a single coherent document.
+
+    Returns:
+        Stats dict with counts of files created per category.
+    """
+    classified_path = os.path.join(config.memory_dir, "migration", "mem0_classified.json")
+    with open(classified_path) as f:
+        memories = json.load(f)
+
+    # Filter out Skip
+    active = [m for m in memories if m.get("type") != "Skip"]
+    skipped = len(memories) - len(active)
+    logger.info(f"Active: {len(active)}, Skipped: {skipped}")
+
+    # Group by slug
+    groups = defaultdict(list)
+    for m in active:
+        group = m.get("group", "unclassified") or "unclassified"
+        groups[group].append(m)
+
+    logger.info(f"Groups: {len(groups)}")
+
+    stats = defaultdict(int)
+
+    for group_slug, mems in groups.items():
+        # Determine category from dominant type
+        type_counts = defaultdict(int)
+        for m in mems:
+            type_counts[m.get("type", "Insight")] += 1
+        dominant_type = max(type_counts, key=type_counts.get)
+        category = TYPE_TO_CATEGORY.get(dominant_type, "inbox")
+
+        # Collect all entities
+        all_entities = list(set(
+            e for m in mems for e in m.get("entities", [])
+        ))
+
+        # Sort memories by date
+        mems.sort(key=lambda m: m.get("created_at", ""))
+
+        # Date range
+        dates = [m.get("created_at", "")[:10] for m in mems if m.get("created_at")]
+        first_date = dates[0] if dates else "unknown"
+        last_date = dates[-1] if dates else "unknown"
+
+        # Build content
+        content_lines = []
+        for m in mems:
+            date = m.get("created_at", "")[:10]
+            source = m.get("source_agent", "?")
+            text = m["content"].strip()
+            if date:
+                content_lines.append(f"- [{date}] {text}")
+            else:
+                content_lines.append(f"- {text}")
+
+        # Title from group slug
+        title = group_slug.replace("-", " ").title()
+
+        # Build frontmatter
+        frontmatter = {
+            "id": f"{category}-{group_slug}",
+            "category": category,
+            "status": "active",
+            "entities": all_entities,
+            "source": "mem0-backfill",
+            "source_agents": list(set(m.get("source_agent", "") for m in mems)),
+            "date_range": f"{first_date} to {last_date}",
+            "memory_count": len(mems),
+            # #193: timezone-aware UTC ISO-8601. Previously ``time.strftime``
+            # emitted local time stamped with the UTC marker ``Z``.
+            "created_at": mems[0].get("created_at", datetime.now(UTC).isoformat()),
+            "last_updated": datetime.now(UTC).isoformat(),
+        }
+
+        doc = f"---\n{yaml.dump(frontmatter, default_flow_style=False)}---\n\n# {title}\n\n"
+        doc += "\n".join(content_lines) + "\n"
+
+        # Write file
+        file_path = os.path.join(config.memory_dir, category, f"{group_slug}.md")
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+
+        # Don't overwrite existing files — append suffix
+        if os.path.exists(file_path):
+            file_path = os.path.join(config.memory_dir, category, f"{group_slug}-mem0.md")
+
+        with open(file_path, "w") as f:
+            f.write(doc)
+
+        stats[category] += 1
+        logger.info(f"  {category}/{group_slug}.md ({len(mems)} memories)")
+
+    # Git commit
+    import subprocess
+    try:
+        subprocess.run(["git", "add", "."], cwd=config.memory_dir, check=False)
+        subprocess.run(
+            ["git", "commit", "-m", f"palinode: Mem0 backfill — {sum(stats.values())} files from {len(active)} memories"],
+            cwd=config.memory_dir, check=False,
+        )
+    except Exception as e:
+        logger.error(f"Git commit failed: {e}")
+
+    return dict(stats)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    stats = generate_files()
+    print(f"Generated: {stats}")

--- a/palinode/migration/openclaw.py
+++ b/palinode/migration/openclaw.py
@@ -235,7 +235,10 @@ def run_migration(
     if review_callback is not None:
         sections = review_callback(sections)
 
-    now_iso = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    # #193: timezone-aware UTC ISO-8601 (``+00:00``). The previous
+    # ``strftime("...Z")`` form emitted UTC stamped as ``Z`` and dropped
+    # sub-second precision — switch to the project standard set by #192.
+    now_iso = datetime.now(UTC).isoformat()
 
     existing_hashes: set[str] = set() if dry_run else _existing_hashes(memory_dir)
 

--- a/palinode/migration/run_mem0_backfill.py
+++ b/palinode/migration/run_mem0_backfill.py
@@ -1,0 +1,58 @@
+"""
+Mem0 Backfill — Full Pipeline
+
+Exports from Qdrant → deduplicates → classifies → generates Palinode files.
+
+Usage:
+    python -m palinode.migration.run_mem0_backfill
+
+This is a one-time migration script. Run it once, review the output,
+then optionally disable Mem0's autoRecall in OpenClaw config.
+"""
+from __future__ import annotations
+
+import logging
+import json
+
+from palinode.migration.mem0_export import export_all
+from palinode.migration.mem0_classify import run_classification, deduplicate
+from palinode.migration.mem0_generate import generate_files
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+)
+logger = logging.getLogger("palinode.migration")
+
+
+def main():
+    # Step 1: Export
+    logger.info("=" * 60)
+    logger.info("STEP 1: Exporting from Qdrant...")
+    export_path = export_all()
+
+    # Step 2: Classify
+    logger.info("=" * 60)
+    logger.info("STEP 2: Deduplicating and classifying...")
+    classified_path = run_classification()
+
+    # Step 3: Generate files
+    logger.info("=" * 60)
+    logger.info("STEP 3: Generating Palinode markdown files...")
+    stats = generate_files()
+
+    # Summary
+    logger.info("=" * 60)
+    logger.info("BACKFILL COMPLETE")
+    logger.info(f"Files generated: {stats}")
+    logger.info(f"Total files: {sum(stats.values())}")
+    logger.info("")
+    logger.info("Next steps:")
+    logger.info("  1. Review the generated files in $PALINODE_DIR/")
+    logger.info("  2. Run 'curl -X POST http://localhost:6340/reindex' to index them")
+    logger.info("  3. Test search: 'curl -X POST http://localhost:6340/search -d {\"query\":\"test\"}'")
+    logger.info("  4. If satisfied, disable Mem0 autoRecall in OpenClaw config")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugin/.gitignore
+++ b/plugin/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+parity-registry.json

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -8,140 +8,1422 @@
       "name": "openclaw-palinode",
       "version": "0.1.0",
       "dependencies": {
-        "@sinclair/typebox": "^0.34.48",
-        "node-fetch": "^3.3.2"
+        "@sinclair/typebox": "0.34.47"
       },
       "devDependencies": {
-        "@types/node": "^20.0.0",
-        "typescript": "^5.0.0"
+        "vitest": "^2.1.9"
       }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.48",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
-      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+      "version": "0.34.47",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.47.tgz",
+      "integrity": "sha512-ZGIBQ+XDvO5JQku9wmwtabcVTHJsgSWAHYtVuM9pBNNR5E88v6Jcj/llpmsjivig5X8A8HHOb4/mbEKPS5EvAw==",
       "license": "MIT"
     },
-    "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
       },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
+        "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
       "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=18"
       }
     },
-    "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 8"
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -7,6 +7,15 @@
     "@sinclair/typebox": "0.34.47"
   },
   "openclaw": {
-    "extensions": ["./index.ts"]
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "scripts": {
+    "pretest": "python3 ../scripts/dump-parity-registry.py > parity-registry.json",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.9"
   }
 }

--- a/plugin/test/parity.test.ts
+++ b/plugin/test/parity.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Plugin-side cross-surface parity test — ADR-010 forcing function for the
+ * OpenClaw plugin (TypeScript surface).
+ *
+ * Mirrors ``tests/test_surface_parity.py``: for every operation in the
+ * canonical registry that has a ``plugin_tool`` set, asserts that each
+ * canonical parameter is declared in the plugin's TypeBox schema, OR that
+ * ``("plugin", param)`` is recorded in ``known_drift`` with a tracking
+ * issue.  Once the drift is resolved (the plugin schema declares the
+ * param), the matching ``known_drift`` entry must be removed — this test
+ * fails loudly when that hasn't happened, which is exactly the point.
+ *
+ * The registry is loaded from ``plugin/parity-registry.json``, regenerated
+ * before each ``npm test`` run by the ``pretest`` script invoking
+ * ``scripts/dump-parity-registry.py``.  No checked-in artifact; the
+ * single source of truth stays at ``palinode/core/parity.py``.
+ *
+ * Plugin schema introspection: we instantiate the default-exported plugin
+ * with a minimal ``OpenClawPluginApi`` shim that captures every
+ * ``registerTool({ name, parameters })`` call.  The plugin's ``register()``
+ * does no real I/O during registration (just ``path.resolve`` for safety
+ * checks), so the shim is a faithful but cheap simulation.
+ */
+
+import { describe, expect, it, beforeAll } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+import palinodePlugin from "../index";
+
+// Vitest's Vite resolver picks up "../index" → "../index.ts" automatically.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// ---------------------------------------------------------------------------
+// Registry loading
+// ---------------------------------------------------------------------------
+
+type Surface = "cli" | "mcp" | "api" | "plugin";
+
+interface CanonicalParam {
+  name: string;
+  type: string;
+  required: boolean;
+  default_key: string | null;
+  enum: string[] | null;
+  notes: string;
+}
+
+interface DriftEntry {
+  surface: Surface;
+  param: string;
+  issue: number;
+}
+
+interface RegistryOperation {
+  name: string;
+  canonical_params: CanonicalParam[];
+  cli_command: string | null;
+  mcp_tool: string | null;
+  api_endpoint: [string, string] | null;
+  plugin_tool: string | null;
+  exempt_surfaces: Surface[];
+  known_drift: DriftEntry[];
+}
+
+interface ParityRegistry {
+  operations: RegistryOperation[];
+  admin_exempt: string[];
+  categories: string[];
+  memory_types: string[];
+  prompt_tasks: string[];
+}
+
+const REGISTRY_PATH = path.resolve(__dirname, "..", "parity-registry.json");
+
+function loadRegistry(): ParityRegistry {
+  if (!fs.existsSync(REGISTRY_PATH)) {
+    throw new Error(
+      `parity-registry.json missing at ${REGISTRY_PATH} — run 'npm test' (the 'pretest' hook regenerates it from palinode/core/parity.py).`,
+    );
+  }
+  const raw = fs.readFileSync(REGISTRY_PATH, "utf-8");
+  return JSON.parse(raw) as ParityRegistry;
+}
+
+// ---------------------------------------------------------------------------
+// Plugin tool introspection — minimal OpenClawPluginApi shim
+// ---------------------------------------------------------------------------
+
+interface CapturedTool {
+  name: string;
+  /** Raw TypeBox schema for the tool's parameters (Type.Object output). */
+  parameters: { type: string; properties: Record<string, unknown>; required?: string[] };
+}
+
+function captureRegisteredTools(): Map<string, CapturedTool> {
+  const tools = new Map<string, CapturedTool>();
+
+  const fakeApi: any = {
+    pluginConfig: {
+      // Use a plausible directory under HOME so resolveWithin's relative
+      // check passes; no filesystem reads happen during register().
+      palinodeDir: path.join(process.env.HOME || "/tmp", "palinode"),
+      promptsDir: "specs/prompts",
+      autoRecall: false, // Skip event handlers; we only care about tool schemas.
+      autoCapture: false,
+      midTurnMode: "none",
+    },
+    logger: {
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+    registerTool: (toolDef: any, _meta?: any) => {
+      if (!toolDef || typeof toolDef.name !== "string") return;
+      tools.set(toolDef.name, {
+        name: toolDef.name,
+        parameters: toolDef.parameters,
+      });
+    },
+    on: () => undefined,
+    registerCli: () => undefined,
+    registerService: () => undefined,
+  };
+
+  palinodePlugin.register(fakeApi);
+  return tools;
+}
+
+function pluginParamNames(tool: CapturedTool | undefined): Set<string> {
+  if (!tool || !tool.parameters || !tool.parameters.properties) {
+    return new Set();
+  }
+  return new Set(Object.keys(tool.parameters.properties));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+let registry: ParityRegistry;
+let pluginTools: Map<string, CapturedTool>;
+
+beforeAll(() => {
+  registry = loadRegistry();
+  pluginTools = captureRegisteredTools();
+});
+
+describe("ADR-010 plugin parity", () => {
+  it("loads at least one operation from the registry", () => {
+    expect(registry.operations.length).toBeGreaterThan(0);
+  });
+
+  it("captures at least one tool from the plugin", () => {
+    expect(pluginTools.size).toBeGreaterThan(0);
+  });
+
+  it("known_drift entries reference real canonical params", () => {
+    // Mirrors test_known_drift_references_a_canonical_param in the Python
+    // suite — drift entries must point at a param that actually exists in
+    // canonical_params, otherwise refactor renames create dangling drift.
+    const bad: string[] = [];
+    for (const op of registry.operations) {
+      const canonicalNames = new Set(op.canonical_params.map((cp) => cp.name));
+      for (const drift of op.known_drift) {
+        if (!canonicalNames.has(drift.param)) {
+          bad.push(`${op.name}: known_drift[("${drift.surface}", "${drift.param}")]`);
+        }
+      }
+    }
+    expect(bad).toEqual([]);
+  });
+});
+
+// Build the case list at module scope so vitest can render one test per
+// (operation, param) pair, matching the Python suite's parametrization.
+function buildCases(): Array<{
+  op: RegistryOperation;
+  param: CanonicalParam;
+  driftIssue: number | null;
+}> {
+  // Need to load the registry synchronously here (before beforeAll runs)
+  // for vitest to enumerate test names at collection time.
+  const reg = loadRegistry();
+  const cases: Array<{
+    op: RegistryOperation;
+    param: CanonicalParam;
+    driftIssue: number | null;
+  }> = [];
+  for (const op of reg.operations) {
+    if (!op.plugin_tool) continue; // Only ops that target the plugin.
+    if (op.exempt_surfaces.includes("plugin")) continue;
+    for (const param of op.canonical_params) {
+      const drift = op.known_drift.find(
+        (d) => d.surface === "plugin" && d.param === param.name,
+      );
+      cases.push({
+        op,
+        param,
+        driftIssue: drift ? drift.issue : null,
+      });
+    }
+  }
+  return cases;
+}
+
+describe("ADR-010 plugin canonical params", () => {
+  const cases = buildCases();
+
+  if (cases.length === 0) {
+    it("registry contains no plugin-bound operations", () => {
+      // If the registry stops listing plugin tools entirely, the test
+      // suite shouldn't silently turn into a no-op — surface it.
+      expect.fail("expected at least one registry operation with plugin_tool set");
+    });
+    return;
+  }
+
+  for (const { op, param, driftIssue } of cases) {
+    const caseId = `${op.name}/plugin/${param.name}`;
+    it(caseId, () => {
+      const tool = pluginTools.get(op.plugin_tool!);
+      const params = pluginParamNames(tool);
+
+      if (driftIssue !== null) {
+        // Drift was tracked: if the surface NOW exposes the param, the
+        // drift entry should be removed.  Failing here is the point —
+        // the test forces drift cleanup.
+        if (params.has(param.name)) {
+          expect.fail(
+            `${op.name}/plugin: param "${param.name}" is now present; ` +
+              `remove known_drift[("plugin", "${param.name}")] from ` +
+              `palinode/core/parity.py and close issue #${driftIssue}.`,
+          );
+        }
+        // Drift is current and the param is missing as expected — passes.
+        return;
+      }
+
+      expect(
+        params.has(param.name),
+        `${op.name}/plugin: canonical param "${param.name}" not exposed ` +
+          `(found: ${[...params].sort().join(", ") || "none"}). ` +
+          `If this is intentional drift, add ` +
+          `known_drift[("plugin", "${param.name}")] = <issue> on the ` +
+          `Operation in palinode/core/parity.py.`,
+      ).toBe(true);
+    });
+  }
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palinode"
-version = "0.7.0"
+version = "0.7.3"
 description = "The memory substrate for AI agents and developer tools. Git-versioned, file-native, MCP-first."
 authors = [
   {name = "Paul Kyle", email = "paul@phasespace.co"}

--- a/scripts/check-httpx-monopoly.sh
+++ b/scripts/check-httpx-monopoly.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# check-httpx-monopoly.sh — enforce ADR-010 HTTP-layer monopoly.
+#
+# Per ADR-010 (Cross-Surface Parity Contract), every CLI command and the
+# plugin must reach the API through one of two HTTP clients:
+#
+#   - palinode/cli/_api.py  (CLI → API)
+#   - palinode/mcp.py       (MCP → API)
+#
+# Direct `httpx` calls from any other source file silently bypass rate
+# limiting, audit logging, the X-Palinode-Source header, and any future
+# API-side fixes.  Each bypass is a parity-rot vector.  We block them at
+# pre-commit / CI time.
+#
+# Usage:
+#   ./scripts/check-httpx-monopoly.sh                 # scan whole tree
+#   ./scripts/check-httpx-monopoly.sh --diff <ref>    # scan files changed vs <ref>
+#   ./scripts/check-httpx-monopoly.sh path/to/file [...] # specific files
+#
+# Exit code: 0 = clean, 1 = bypass found.
+#
+# The known-grandfathered bypass list is encoded below.  Cleaning these is
+# tracked in #168 and the lower-tier of #170; until that work lands the
+# script reports them but does not fail.  Any *new* bypass fails.
+
+set -euo pipefail
+
+# Scope: CLI files (`palinode/cli/*.py`) talking to the Palinode API.
+# Outbound HTTP to *other* services (Ollama, source URLs, mem0/migration
+# endpoints) is unrelated to ADR-010 and lives in core/ingest/migration/
+# consolidation/api modules — we don't scan those.
+SCAN_GLOBS=(
+    "palinode/cli/*.py"
+)
+
+# Within SCAN_GLOBS, this file is the canonical HTTP client.
+ALLOWED_FILES=(
+    "palinode/cli/_api.py"
+)
+
+# Files known to violate today.  Tracked for cleanup; allowed for now.
+# When the cleanup PR lands, remove the file from this list — the script then
+# fails if the bypass returns.
+#
+# As of the lower-tier #170 cleanup the list is empty: list/lint/prompt/
+# ingest/session_end have all moved to PalinodeAPI in palinode/cli/_api.py.
+# The historical disk-read bypass in cli/read.py was closed earlier in #168
+# (it now goes through `api_client.read()`).  Any *new* bypass fails.
+GRANDFATHERED=(
+)
+
+# Determine scan set
+mode="all"
+files=()
+if [[ "${1:-}" == "--diff" ]]; then
+    mode="diff"
+    base="${2:-origin/main}"
+    while IFS= read -r f; do
+        [[ -n "$f" ]] && files+=("$f")
+    done < <(git diff --name-only --diff-filter=AM "$base" -- 'palinode/**/*.py' 'plugin/**/*.ts' 2>/dev/null || true)
+elif [[ $# -gt 0 ]]; then
+    mode="specific"
+    files=("$@")
+else
+    for glob in "${SCAN_GLOBS[@]}"; do
+        while IFS= read -r f; do
+            [[ -n "$f" ]] && files+=("$f")
+        done < <(compgen -G "$glob" 2>/dev/null || true)
+    done
+fi
+
+if [[ ${#files[@]} -eq 0 ]]; then
+    echo "check-httpx-monopoly: no files to scan ($mode mode)"
+    exit 0
+fi
+
+is_allowed() {
+    local f="$1"
+    for a in "${ALLOWED_FILES[@]}"; do
+        [[ "$f" == "$a" || "$f" == */"$a" ]] && return 0
+    done
+    return 1
+}
+
+is_grandfathered() {
+    local f="$1"
+    for g in "${GRANDFATHERED[@]}"; do
+        [[ "$f" == "$g" || "$f" == */"$g" ]] && return 0
+    done
+    return 1
+}
+
+violations=0
+warnings=0
+
+for f in "${files[@]}"; do
+    [[ -f "$f" ]] || continue
+    is_allowed "$f" && continue
+
+    # Look for raw httpx use.  ``import httpx`` and ``httpx.<method>`` calls
+    # are the bypass markers.  We allow ``import httpx`` only if it's used
+    # for type hints (``httpx.Response``, ``httpx.Client``) without instance
+    # creation — but that's hard to grep cleanly, so we report the import
+    # and let the reviewer judge.  In practice every today-bypass file does
+    # actual HTTP calls; the conservative default is to flag.
+    if grep -qE '^[[:space:]]*import[[:space:]]+httpx|^[[:space:]]*from[[:space:]]+httpx[[:space:]]+import|httpx\.(get|post|put|delete|patch|request|Client|AsyncClient)' "$f"; then
+        if is_grandfathered "$f"; then
+            echo "warn: $f uses httpx directly (grandfathered, see ADR-010 / #170)"
+            warnings=$((warnings + 1))
+        else
+            echo "fail: $f uses httpx directly — go through palinode/cli/_api.py or palinode/mcp.py"
+            violations=$((violations + 1))
+        fi
+    fi
+done
+
+if [[ $violations -gt 0 ]]; then
+    echo
+    echo "ADR-010 (HTTP-layer monopoly) violation: $violations file(s) bypass the API client."
+    echo "If a new bypass is intentional, document the carve-out in docs/PARITY.md and update this script."
+    exit 1
+fi
+
+if [[ $warnings -gt 0 ]]; then
+    echo
+    echo "$warnings grandfathered bypass(es) noted (cleanup tracked in #170)."
+fi
+
+exit 0

--- a/scripts/check-shipping-leaks.sh
+++ b/scripts/check-shipping-leaks.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+# check-shipping-leaks.sh — fast pre-merge leak scanner for public-shipping files.
+#
+# Unlike scripts/scrub-check.sh (which scans an entire public-tree clone),
+# this scans only the files that would ship publicly, in the dev repo, on
+# the current branch. Designed for speed: run as a pre-commit hook or in
+# CI on every PR.
+#
+# Usage:
+#   ./scripts/check-shipping-leaks.sh --diff origin/main       # scan only files changed vs origin/main (recommended)
+#   ./scripts/check-shipping-leaks.sh path/to/file.py [...]    # scan specific files
+#   ./scripts/check-shipping-leaks.sh                          # scan all shipping files on HEAD (audit mode)
+#
+# Exit code: 0 = clean, 1 = leaks found.
+#
+# IMPORTANT: this script enforces the rule "NO NEW LEAKS at PR time," not
+# "all of dev main is leak-free." Dev main carries a baseline of legitimate
+# private references (e.g. Phase-B holdout files, internal issue trackers,
+# old-org URLs in long-lived docs) that get scrubbed at staging-build time
+# via the standard scrub commits — see .claude/plans/phase-a-codex-handoff.md.
+#
+# CI runs with `--diff origin/main` to fail only on NEW introductions.
+# The full-audit mode (no args) will return baseline noise; useful for
+# dev hygiene work but not for gating PRs.
+
+set -euo pipefail
+
+# Patterns that must NEVER appear in public-shipping files.
+# Synced with scripts/scrub-check.sh and SYNC-PUBLIC.md.
+PATTERNS=(
+    # Private IPs and infrastructure
+    '10\.2\.1\.(61|65|69)'
+    '100\.83\.166'
+    '100\.108\.11'
+    '\.ts\.net'
+    'tailscale'
+    'clawdbot'
+
+    # Personal paths and usernames
+    '/home/clawd'
+    '~/clawd/'
+    'clawd@'
+    'paul-kyle-pedro'
+
+    # Private repo references
+    'palinode-dev'
+
+    # Email addresses
+    'grue\.lurker'
+
+    # Infrastructure specifics
+    'deploy_5060'
+    'engram-data'
+    'engram-api'
+    'engram-watcher'
+
+    # Internal planning doc names
+    'POST-STRATEGY'
+    'PUBLIC-LAUNCH-PLAN'
+    'AGENT-ROADMAP'
+    'CODEX-REVIEW-PROMPT'
+    'GOVERNOR-MEM0-DISABLE'
+
+    # Patent-adjacent vocabulary that's hard-private until counsel clears
+    '[Cc]olophon'
+    'mm-kmd'
+    'antigravity'
+    'color-class'
+
+    # Old-org URLs that should now point at phasespace-labs
+    'github\.com/Paul-Kyle/palinode([/-]|\.git|$)'
+)
+
+# Paths that DON'T ship publicly. Files matching these are skipped from
+# the scan. Mirrors the rsync exclude list in
+# .claude/plans/phase-a-codex-handoff.md and SYNC-PUBLIC.md.
+DEV_ONLY_PREFIXES=(
+    'specs/'
+    'artifacts/'
+    '.roo'
+    'SYNC-PUBLIC.md'
+    'docs/AGENT-ROADMAP.md'
+    'docs/colophon-derivation/'
+    '.claude/'
+    '__pycache__'
+    '.pytest_cache'
+    '.venv'
+    '.git/'
+    'build/'
+    'dist/'
+    'HANDOFF.md'
+    'PLAN.md'
+    'TODO-PAUL.md'
+    'FEATURES.md'
+    'AGENTS.md'
+    'CLAUDE.md'
+    'deploy_5060.sh'
+    'notes/'
+    # Phase-B holdouts — the capabilities + actor-class scaffold lived on
+    # dev main from 2026-04-19 to 2026-04-26 and was reverted in 12934e1
+    # per the colophon-cleanup decision. The paths below no longer exist
+    # on dev main; they're listed only because re-introducing them at
+    # resume time should remain caught by the [Cc]olophon pattern in the
+    # blacklist above (i.e. these excludes are intentionally NOT here, so
+    # any future palinode/capabilities/record.py shipping a colophon_*
+    # field name fails the lint at PR time, the way it should).
+    # ADR-*.md: default-private per migration plan (2026-04-19 revision).
+    # Every staging build deletes them; this lint should not flag them either.
+    'ADR-001-tools-over-pipeline.md'
+    'ADR-002-watcher-fault-isolation.md'
+    'ADR-003-memory-harness-boundary.md'
+    'ADR-004-event-driven-consolidation.md'
+    'ADR-005-debounced-reflection-executor.md'
+    'ADR-006-on-read-reconsolidation.md'
+    'ADR-007-access-metadata-and-decay.md'
+    'ADR-008-ambient-context-search.md'
+    'ADR-009-scoped-memory-context-prime.md'
+    # Dev-only Antigravity-sync script (deleted on the staging branch).
+    'scripts/sync-ag-artifacts.sh'
+    # Dev-only PR template — uses internal vocabulary (palinode-dev,
+    # Colophon-adjacent, Phase A/B). Public repo gets its own template.
+    # Mirrored in .claude/plans/phase-a-codex-handoff.md's rsync exclude.
+    '.github/PULL_REQUEST_TEMPLATE.md'
+)
+
+# Paths the scrub source itself uses (legitimate occurrences of the
+# patterns above). Skip them so the scanner doesn't false-positive on
+# its own pattern list.
+SCANNER_SOURCES=(
+    'scripts/scrub-check.sh'
+    'scripts/check-shipping-leaks.sh'
+)
+
+# Allow specs/prompts/ even though specs/ is excluded above (the prompts
+# subdirectory is the one part of specs that DOES ship publicly).
+SHIPPING_ALLOWLIST=(
+    'specs/prompts/'
+)
+
+# ── Build the file list ───────────────────────────────────────────────────────
+
+FILES=()
+MODE="all"
+DIFF_REF=""
+
+if [ "$#" -ge 2 ] && [ "$1" = "--diff" ]; then
+    MODE="diff"
+    DIFF_REF="$2"
+    shift 2
+fi
+
+if [ "$MODE" = "diff" ]; then
+    while IFS= read -r line; do
+        [ -n "$line" ] && FILES+=("$line")
+    done < <(git diff --name-only --diff-filter=AM "$DIFF_REF"...HEAD 2>/dev/null || true)
+elif [ "$#" -gt 0 ]; then
+    MODE="explicit"
+    for f in "$@"; do
+        FILES+=("$f")
+    done
+else
+    while IFS= read -r line; do
+        [ -n "$line" ] && FILES+=("$line")
+    done < <(git ls-files)
+fi
+
+# Bash safety: empty array dereference is an error under `set -u`.
+if [ "${#FILES[@]}" -eq 0 ]; then
+    echo "check-shipping-leaks: no input files (mode=$MODE) — nothing to scan."
+    exit 0
+fi
+
+# ── Filter to public-shipping files ───────────────────────────────────────────
+
+is_dev_only() {
+    local f="$1"
+    for allow in "${SHIPPING_ALLOWLIST[@]}"; do
+        case "$f" in
+            "$allow"*) return 1 ;;
+        esac
+    done
+    for p in "${DEV_ONLY_PREFIXES[@]}"; do
+        case "$f" in
+            "$p"*) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+is_scanner_source() {
+    local f="$1"
+    for s in "${SCANNER_SOURCES[@]}"; do
+        [ "$f" = "$s" ] && return 0
+    done
+    return 1
+}
+
+SHIPPING=()
+for f in "${FILES[@]}"; do
+    [ -f "$f" ] || continue
+    is_dev_only "$f" && continue
+    is_scanner_source "$f" && continue
+    SHIPPING+=("$f")
+done
+
+if [ "${#SHIPPING[@]}" -eq 0 ]; then
+    echo "check-shipping-leaks: no public-shipping files in scope (mode=$MODE) — nothing to scan."
+    exit 0
+fi
+
+# ── Scan ──────────────────────────────────────────────────────────────────────
+
+FAILED=0
+echo "check-shipping-leaks: scanning ${#SHIPPING[@]} files (mode=$MODE)"
+echo ""
+
+for pattern in "${PATTERNS[@]}"; do
+    matches=$(/usr/bin/grep -nE "$pattern" "${SHIPPING[@]}" 2>/dev/null || true)
+    if [ -n "$matches" ]; then
+        echo "LEAK — pattern: $pattern"
+        echo "$matches" | head -5
+        echo ""
+        FAILED=1
+    fi
+done
+
+if [ $FAILED -eq 0 ]; then
+    echo "OK — no leak patterns found in shipping files."
+    exit 0
+fi
+
+echo "FAILED — fix the leaks above before merging. If a pattern is a"
+echo "false-positive (e.g. a documentation example), either:"
+echo "  - rename it to a neutral form (preferred), or"
+echo "  - add the file to SCANNER_SOURCES in this script if it's"
+echo "    legitimately listing the pattern by design."
+exit 1

--- a/scripts/dump-parity-registry.py
+++ b/scripts/dump-parity-registry.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Dump ``palinode.core.parity`` to deterministic JSON on stdout.
+
+Consumers (the plugin TS-side parity test, future TS tooling) read this
+artifact instead of parsing Python.  ADR-010 keeps ``parity.py`` as the
+single source of truth; this script is only a serializer.
+
+Usage::
+
+    python scripts/dump-parity-registry.py > plugin/parity-registry.json
+
+Output is sorted (operations by name, params by index, drift entries by
+``(surface, param)``) so JSON diffs stay clean across runs.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+# Allow running from anywhere — add repo root to sys.path so ``palinode``
+# imports work without ``pip install -e .``.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from palinode.core.parity import (  # noqa: E402  (sys.path mutation above)
+    ADMIN_EXEMPT_OPERATIONS,
+    CATEGORIES,
+    MEMORY_TYPES,
+    PROMPT_TASKS,
+    REGISTRY,
+)
+
+
+def _canonical_param_to_dict(cp: Any) -> dict[str, Any]:
+    """Serialize a CanonicalParam preserving every field, with stable ordering."""
+    return {
+        "name": cp.name,
+        "type": cp.type,
+        "required": cp.required,
+        "default_key": cp.default_key,
+        "enum": list(cp.enum) if cp.enum is not None else None,
+        "notes": cp.notes,
+    }
+
+
+def _operation_to_dict(op: Any) -> dict[str, Any]:
+    """Serialize an Operation including known_drift, normalized for JSON."""
+    drift_entries = sorted(
+        (
+            {
+                "surface": surface,
+                "param": param_name,
+                "issue": issue,
+            }
+            for (surface, param_name), issue in op.known_drift.items()
+        ),
+        key=lambda d: (d["surface"], d["param"]),
+    )
+    return {
+        "name": op.name,
+        "canonical_params": [_canonical_param_to_dict(cp) for cp in op.canonical_params],
+        "cli_command": op.cli_command,
+        "mcp_tool": op.mcp_tool,
+        "api_endpoint": list(op.api_endpoint) if op.api_endpoint is not None else None,
+        "plugin_tool": op.plugin_tool,
+        "exempt_surfaces": sorted(op.exempt_surfaces),
+        "known_drift": drift_entries,
+    }
+
+
+def build_payload() -> dict[str, Any]:
+    operations = sorted(
+        (_operation_to_dict(op) for op in REGISTRY),
+        key=lambda d: d["name"],
+    )
+    return {
+        "operations": operations,
+        "admin_exempt": sorted(ADMIN_EXEMPT_OPERATIONS),
+        "categories": list(CATEGORIES),
+        "memory_types": list(MEMORY_TYPES),
+        "prompt_tasks": list(PROMPT_TASKS),
+    }
+
+
+def main() -> int:
+    payload = build_payload()
+    json.dump(payload, sys.stdout, indent=2, sort_keys=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_session_end_e2e_l1_l3.py
+++ b/tests/integration/test_session_end_e2e_l1_l3.py
@@ -1,0 +1,422 @@
+"""End-to-end integration test for the `/wrap` save-and-resume loop (issue #139).
+
+Covers layers 1-3 of the four-layer validation model documented in
+`docs/VALIDATION-STRATEGY.md`:
+
+  L1 - Tool fired: `palinode session-end` returns success.
+  L2 - Data on disk: daily note, project-status file, and individual indexed
+       file all exist with the expected frontmatter.
+  L3 - Retrievable: a fresh client (separate from the writer) issues
+       `POST /search` against the on-disk SQLite DB and surfaces the record.
+
+Layer 4 (LLM-in-the-loop behavioural test) is deferred — see
+`docs/L4-BEHAVIORAL-TESTING-DESIGN.md` for the design sketch and tradeoffs,
+and issue #140 for the LLM-prompt-fidelity counterpart.
+
+The test uses `tmp_path` for the memory directory and FastAPI's `TestClient`
+so it neither touches the user's real `~/palinode` nor needs Ollama running.
+The CLI is invoked with Click's `CliRunner`; the singleton ``PalinodeAPI``
+client (``palinode.cli._api.api_client``) has its underlying ``httpx.Client``
+swapped for one with an ``ASGITransport`` so its requests dispatch in-process
+to the same FastAPI app the test uses for ``TestClient``. The M0 dual-write
+(daily append + indexed individual file) thus round-trips end-to-end without
+touching the network. (Test-fixture fix for #195 after #178's ADR-010 rewrite
+moved the CLI off the module-level ``httpx.post`` the previous patch hooked.)
+"""
+from __future__ import annotations
+
+import glob
+import hashlib
+import os
+from datetime import datetime, timezone
+from unittest import mock
+
+import httpx
+import pytest
+import yaml
+from click.testing import CliRunner
+from fastapi.testclient import TestClient
+
+from palinode.core.config import config
+
+
+EMBED_DIM = 1024
+
+
+def _fake_embed(text: str, backend: str = "local") -> list[float]:
+    """Deterministic fake embedder so tests don't need Ollama."""
+    return [0.1] * EMBED_DIM
+
+
+def _today() -> str:
+    """The same UTC date stamp the CLI uses to name daily / individual files."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _expected_individual_path(memory_dir: str, summary: str, project: str | None) -> str:
+    """Recreate the slug logic from `palinode session-end` to find the
+    individual file the CLI's API dual-write produced."""
+    today = _today()
+    short_hash = hashlib.sha256(summary.encode()).hexdigest()[:8]
+    if project:
+        slug = f"session-end-{today}-{project}-{short_hash}"
+        category = "projects"
+    else:
+        slug = f"session-end-{today}-{short_hash}"
+        category = "insights"
+    return os.path.join(memory_dir, category, f"{slug}.md")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def isolated_memory(tmp_path, monkeypatch):
+    """Point the global config at a fresh tmp memory dir and init real SQLite.
+
+    Mirrors the fixture used by `tests/integration/test_api_roundtrip.py` but
+    is request-scoped (not autouse) so individual tests can opt in explicitly.
+    """
+    memory_dir = str(tmp_path)
+    db_path = os.path.join(memory_dir, ".palinode.db")
+
+    monkeypatch.setattr(config, "memory_dir", memory_dir)
+    monkeypatch.setattr(config, "db_path", db_path)
+    monkeypatch.setattr(config.git, "auto_commit", False)
+
+    for d in ("people", "projects", "decisions", "insights", "research", "inbox", "daily"):
+        os.makedirs(os.path.join(memory_dir, d), exist_ok=True)
+
+    from palinode.core import store
+    store.init_db()
+
+    with (
+        mock.patch("palinode.core.embedder.embed", side_effect=_fake_embed),
+        mock.patch("palinode.api.server._generate_description", return_value="Test description"),
+        mock.patch("palinode.api.server._generate_summary", return_value=""),
+    ):
+        yield memory_dir
+
+
+@pytest.fixture()
+def api_client():
+    """Fresh TestClient against the FastAPI app."""
+    from palinode.api.server import app, _rate_counters
+    _rate_counters.clear()
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture()
+def cli_with_api_redirect(api_client):
+    """Route the CLI's API singleton through the in-process FastAPI app.
+
+    Post-#178 (ADR-010), ``palinode session-end`` no longer calls
+    ``httpx.post`` directly — it goes through the ``PalinodeAPI`` singleton
+    in ``palinode.cli._api`` whose long-lived ``httpx.Client`` carries the
+    ``X-Palinode-Source: cli`` header. The previous fixture patched
+    ``httpx.post`` (the module-level function), which the new code path
+    doesn't use, so the CLI tried to reach a real localhost:6340 and failed
+    with ``ECONNREFUSED`` (#195).
+
+    The fix: swap ``api_client.client`` for an ``httpx.Client`` whose
+    transport delegates each request to the in-process FastAPI ``TestClient``
+    (the same one this test's assertions use). httpx's built-in
+    ``ASGITransport`` is async-only and can't drive a sync ``httpx.Client``;
+    ``MockTransport`` lets us return responses synchronously, so we use it
+    as a thin shim over ``TestClient.request`` (which already handles the
+    portal/threadpool dance for the ASGI app).
+
+    The CLI's ``self.client.post(...)`` thus dispatches in-process to the
+    same app the test uses for ``TestClient`` — no network, no patching of
+    individual call sites, and the real ``PalinodeAPI`` body-shaping /
+    error-translation code path is exercised end-to-end.
+    """
+    from palinode.cli._api import api_client as cli_api_client
+    from palinode.core.defaults import SAVE_SOURCE_HEADER
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        # Delegate to the in-process TestClient so the FastAPI app handles
+        # the request the same way it would in production. Forward method,
+        # path+query, headers, and body; let TestClient propagate the
+        # response (status, headers, body) back as an httpx.Response.
+        path = request.url.raw_path.decode("ascii")
+        tc_response = api_client.request(
+            request.method,
+            path,
+            content=request.content,
+            headers=dict(request.headers),
+        )
+        return httpx.Response(
+            status_code=tc_response.status_code,
+            headers=tc_response.headers.multi_items(),
+            content=tc_response.content,
+            request=request,
+        )
+
+    original_client = cli_api_client.client
+    cli_api_client.client = httpx.Client(
+        transport=httpx.MockTransport(_handler),
+        base_url="http://testserver",
+        timeout=30.0,
+        headers={SAVE_SOURCE_HEADER: "cli"},
+    )
+    try:
+        yield
+    finally:
+        cli_api_client.client.close()
+        cli_api_client.client = original_client
+
+
+def _index_file(file_path: str) -> None:
+    """Manually drive the watcher's per-file indexing path.
+
+    The integration test does not run the watcher daemon — invoking
+    `PalinodeHandler._process_file` directly is the same code that `on_created`
+    would have run, minus the OS event plumbing.
+    """
+    from palinode.indexer.watcher import PalinodeHandler
+    handler = PalinodeHandler()
+    handler._process_file(file_path)
+
+
+# ---------------------------------------------------------------------------
+# L1 — Tool fired
+# ---------------------------------------------------------------------------
+
+
+def test_l1_cli_session_end_returns_success(isolated_memory, cli_with_api_redirect, api_client):
+    """`palinode session-end "<summary>"` exits 0 and the CLI's primary
+    side effect (a daily note with today's stamp) lands on disk.
+
+    L1 is the smallest layer: did the tool fire without crashing? We check
+    the exit code and confirm the CLI's primary write path produced output
+    on disk. L2 dives deeper into content; L3 dives deeper into retrieval.
+    """
+    from palinode.cli.session_end import session_end
+
+    runner = CliRunner()
+    summary = "Implemented L1-L3 integration test for issue #139"
+    result = runner.invoke(
+        session_end,
+        [
+            summary,
+            "-d", "Use TestClient + httpx redirect for dual-write",
+            "-b", "L4 deferred to design doc",
+            "-p", "palinode",
+            "--source", "test",
+        ],
+    )
+
+    assert result.exit_code == 0, f"CLI failed: {result.output}\n{result.exception}"
+    # The CLI prints a confirmation that names the daily file path
+    assert "daily/" in result.output
+    # And the daily file actually exists on disk
+    daily_path = os.path.join(isolated_memory, "daily", f"{_today()}.md")
+    assert os.path.exists(daily_path), f"daily note not at {daily_path}"
+
+
+# ---------------------------------------------------------------------------
+# L2 — Data on disk
+# ---------------------------------------------------------------------------
+
+
+def test_l2_daily_note_and_project_status_and_individual_file(
+    isolated_memory, cli_with_api_redirect, api_client
+):
+    """Daily note, project-status, and individual indexed file all exist
+    with the right shape after a `palinode session-end -p <project>` call."""
+    memory_dir = isolated_memory
+
+    # Pre-create the project status file so the CLI's append path runs
+    status_path = os.path.join(memory_dir, "projects", "palinode-status.md")
+    with open(status_path, "w") as f:
+        f.write("# palinode status\n")
+
+    summary = "L2 test — wrote daily, status, and indexed individual file"
+
+    from palinode.cli.session_end import session_end
+    runner = CliRunner()
+    result = runner.invoke(
+        session_end,
+        [
+            summary,
+            "-d", "Daily append remains the primary path",
+            "-d", "Individual file enables fine-grained recall",
+            "-b", "Watcher is mocked here; daemon path is covered by other tests",
+            "-p", "palinode",
+            "--source", "test",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    # --- Daily note ------------------------------------------------------
+    daily_path = os.path.join(memory_dir, "daily", f"{_today()}.md")
+    assert os.path.exists(daily_path), f"daily note not found at {daily_path}"
+    daily_text = open(daily_path).read()
+    assert "## Session End" in daily_text
+    assert summary in daily_text
+    assert "Daily append remains the primary path" in daily_text
+    assert "Individual file enables fine-grained recall" in daily_text
+    assert "Watcher is mocked here" in daily_text
+    assert "**Source:** test" in daily_text
+
+    # --- Project status --------------------------------------------------
+    status_text = open(status_path).read()
+    assert summary[:80] in status_text, "project-status file did not get the new entry"
+    assert f"[{_today()}]" in status_text, "status entry must be date-stamped"
+
+    # --- Individual indexed file ----------------------------------------
+    individual_path = _expected_individual_path(memory_dir, summary, project="palinode")
+    assert os.path.exists(individual_path), (
+        f"individual file not at {individual_path}; "
+        f"projects/ has {os.listdir(os.path.join(memory_dir, 'projects'))}"
+    )
+    ind_text = open(individual_path).read()
+    # Frontmatter must round-trip type, project entity, and the source
+    parts = ind_text.split("---", 2)
+    fm = yaml.safe_load(parts[1])
+    assert fm["type"] == "ProjectSnapshot", fm
+    assert "project/palinode" in fm["entities"], fm
+    assert fm["category"] == "projects"
+    assert fm["source"] == "test"
+    # The indexed body must carry the full session-end entry, not just the summary
+    assert summary in ind_text
+
+
+def test_l2_no_project_lands_in_insights(isolated_memory, cli_with_api_redirect, api_client):
+    """Without -p, the individual file is an Insight in `insights/` and there
+    is no project-status side effect."""
+    memory_dir = isolated_memory
+    summary = "Quick session — no project specified"
+
+    from palinode.cli.session_end import session_end
+    runner = CliRunner()
+    result = runner.invoke(
+        session_end,
+        [summary, "--source", "test"],
+    )
+    assert result.exit_code == 0, result.output
+
+    individual_path = _expected_individual_path(memory_dir, summary, project=None)
+    assert os.path.exists(individual_path), (
+        f"individual file not at {individual_path}; "
+        f"insights/ has {os.listdir(os.path.join(memory_dir, 'insights'))}"
+    )
+    ind_text = open(individual_path).read()
+    fm = yaml.safe_load(ind_text.split("---", 2)[1])
+    assert fm["type"] == "Insight"
+    assert fm["category"] == "insights"
+    # No project ⇒ no project entity ref
+    assert all(not str(e).startswith("project/") for e in fm.get("entities", []))
+
+
+# ---------------------------------------------------------------------------
+# L3 — Retrievable
+# ---------------------------------------------------------------------------
+
+
+def test_l3_search_finds_session_end_record_after_indexing(
+    isolated_memory, cli_with_api_redirect, api_client
+):
+    """After `palinode session-end` writes, indexing the new file makes the
+    record retrievable via `POST /search`. This proves the indexer + search
+    surface picks up session-end captures end-to-end.
+
+    A *fresh* TestClient (one that did not handle any of the writes) is the
+    one issuing the search — that simulates the cross-session-boundary
+    recall path the four-layer model exists to validate.
+    """
+    memory_dir = isolated_memory
+    distinctive_phrase = "marmot-quokka-zither"  # unlikely to collide with anything
+    summary = f"L3 retrieval test — distinctive token {distinctive_phrase}"
+
+    from palinode.cli.session_end import session_end
+    runner = CliRunner()
+    result = runner.invoke(
+        session_end,
+        [
+            summary,
+            "-d", f"Search must surface the {distinctive_phrase} token",
+            "-p", "palinode",
+            "--source", "test",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    individual_path = _expected_individual_path(memory_dir, summary, project="palinode")
+    assert os.path.exists(individual_path)
+
+    # Drive the watcher's per-file indexing path explicitly. In production
+    # the watchdog daemon does this automatically on file create; here we
+    # invoke `_process_file` directly so the test is hermetic and fast.
+    _index_file(individual_path)
+
+    # Sanity: chunks landed in the DB
+    from palinode.core import store
+    stats = store.get_stats()
+    total = stats.get("total_chunks") or stats.get("chunks") or 0
+    assert total >= 1, f"expected at least one indexed chunk, got {stats}"
+
+    # ---- The L3 assertion -------------------------------------------------
+    # A fresh TestClient (separate from the one that fired the writes)
+    # issues POST /search. It reads the SQLite DB on disk, so a hit here
+    # proves the indexed record is retrievable across "session boundaries".
+    from palinode.api.server import app, _rate_counters
+    _rate_counters.clear()
+    fresh_client = TestClient(app, raise_server_exceptions=False)
+
+    resp = fresh_client.post(
+        "/search",
+        json={"query": distinctive_phrase, "threshold": 0.0, "limit": 5},
+    )
+    assert resp.status_code == 200, resp.text
+    results = resp.json()
+    assert len(results) >= 1, "search returned no results — index missed the new file"
+
+    # The hit must reference the individual file we just wrote
+    matched = [
+        r for r in results
+        if individual_path in r.get("file_path", "") or individual_path in r.get("file", "")
+    ]
+    assert matched, (
+        f"none of the {len(results)} hits matched {individual_path}: "
+        f"{[r.get('file_path') or r.get('file') for r in results]}"
+    )
+
+
+def test_l3_keyword_search_via_fts_surfaces_session_end(
+    isolated_memory, cli_with_api_redirect, api_client
+):
+    """A second L3 angle: hybrid search (BM25 + vector) finds the record by
+    a keyword that appears in the session-end summary but not the surrounding
+    boilerplate. Guards against the vector-only path masking an FTS gap."""
+    memory_dir = isolated_memory
+    keyword = "axolotl"  # uncommon token — appears only in our summary
+    summary = f"Session covered the {keyword} migration plan"
+
+    from palinode.cli.session_end import session_end
+    runner = CliRunner()
+    result = runner.invoke(
+        session_end,
+        [summary, "-p", "palinode", "--source", "test"],
+    )
+    assert result.exit_code == 0, result.output
+
+    individual_path = _expected_individual_path(memory_dir, summary, project="palinode")
+    assert os.path.exists(individual_path)
+    _index_file(individual_path)
+
+    from palinode.api.server import app, _rate_counters
+    _rate_counters.clear()
+    fresh_client = TestClient(app, raise_server_exceptions=False)
+    resp = fresh_client.post(
+        "/search",
+        json={"query": keyword, "threshold": 0.0, "limit": 5, "hybrid": True},
+    )
+    assert resp.status_code == 200, resp.text
+    results = resp.json()
+    assert any(
+        keyword in (r.get("content") or "") for r in results
+    ), f"keyword {keyword!r} not surfaced in {results}"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -14,10 +14,10 @@ def test_search_hybrid_context_boost():
                     # Two results: palinode file and other-project file, initially ranked equally
                     mock_vec.return_value = [
                         {"file_path": "/mem/projects/palinode-adr.md", "content": "ADR-004", "score": 0.85},
-                        {"file_path": "/mem/projects/other-adr.md", "content": "ADR-052", "score": 0.86},
+                        {"file_path": "/mem/projects/kmd-adr.md", "content": "ADR-052", "score": 0.86},
                     ]
                     mock_fts.return_value = [
-                        {"file_path": "/mem/projects/other-adr.md", "content": "ADR-052", "score": 0.7},
+                        {"file_path": "/mem/projects/kmd-adr.md", "content": "ADR-052", "score": 0.7},
                         {"file_path": "/mem/projects/palinode-adr.md", "content": "ADR-004", "score": 0.6},
                     ]
                     # Entity lookup: project/palinode maps to the palinode file

--- a/tests/test_migrate_openclaw.py
+++ b/tests/test_migrate_openclaw.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import textwrap
+from datetime import UTC
 from pathlib import Path
 from unittest.mock import patch
 
@@ -235,7 +236,21 @@ def test_migration_frontmatter_fields(
 def test_deduplication_skips_identical_content(
     memory_md_file: Path, fake_memory_dir: Path
 ) -> None:
-    with patch("palinode.migration.openclaw.config") as mock_cfg:
+    # Freeze datetime.now so both runs produce byte-identical frontmatter
+    # (the dedup hash is over the full file content, including the
+    # `last_updated` timestamp — a real wall-clock tick between the two
+    # calls would defeat dedup and flake the test).
+    from datetime import datetime as _real_datetime
+
+    fixed_now = _real_datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+    class _FrozenDatetime(_real_datetime):
+        @classmethod
+        def now(cls, tz=None):  # type: ignore[override]
+            return fixed_now if tz is None else fixed_now.astimezone(tz)
+
+    with patch("palinode.migration.openclaw.config") as mock_cfg, \
+         patch("palinode.migration.openclaw.datetime", _FrozenDatetime):
         mock_cfg.memory_dir = str(fake_memory_dir)
         result1 = run_migration(str(memory_md_file), dry_run=False)
         result2 = run_migration(str(memory_md_file), dry_run=False)

--- a/tests/test_save_project.py
+++ b/tests/test_save_project.py
@@ -1,0 +1,133 @@
+"""
+Tests for the ``project`` shorthand on save (ADR-010 / #159).
+
+``project="palinode"`` on the API/CLI/MCP save surface is sugar for
+appending ``"project/palinode"`` to ``entities``.  A pre-prefixed value
+is left as-is.  Both ``project`` and ``entities`` may be supplied
+together — the project ref is appended if not already present.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from palinode.api.server import app
+from palinode.core.config import config
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def mock_memory_dir(tmp_path):
+    old = config.memory_dir
+    config.memory_dir = str(tmp_path)
+    yield str(tmp_path)
+    config.memory_dir = old
+
+
+def _frontmatter(file_path: str) -> dict:
+    with open(file_path, "r") as f:
+        text = f.read()
+    # Frontmatter is between the first two `---` lines.
+    parts = text.split("---", 2)
+    assert len(parts) >= 3, f"no frontmatter in {file_path}: {text[:120]}"
+    return yaml.safe_load(parts[1])
+
+
+def test_project_shorthand_adds_entity(mock_memory_dir):
+    """Bare ``project`` slug becomes a ``project/<slug>`` entity."""
+    with patch("palinode.core.store.scan_memory_content", return_value=(True, "OK")):
+        res = client.post(
+            "/save",
+            json={"content": "x", "type": "Decision", "project": "palinode"},
+        )
+        assert res.status_code == 200, res.text
+        fm = _frontmatter(res.json()["file_path"])
+        assert "project/palinode" in fm["entities"]
+
+
+def test_project_already_prefixed_left_alone(mock_memory_dir):
+    """Caller passing ``project='project/palinode'`` is honored as-is."""
+    with patch("palinode.core.store.scan_memory_content", return_value=(True, "OK")):
+        res = client.post(
+            "/save",
+            json={"content": "x", "type": "Decision", "project": "project/palinode"},
+        )
+        assert res.status_code == 200, res.text
+        fm = _frontmatter(res.json()["file_path"])
+        assert "project/palinode" in fm["entities"]
+        # No double-prefixed entry like ``project/project/palinode``.
+        assert all(not e.startswith("project/project/") for e in fm["entities"])
+
+
+def test_project_merges_with_explicit_entities(mock_memory_dir):
+    """``project`` and ``entities`` together compose without duplication."""
+    with patch("palinode.core.store.scan_memory_content", return_value=(True, "OK")):
+        res = client.post(
+            "/save",
+            json={
+                "content": "x",
+                "type": "Decision",
+                "project": "palinode",
+                "entities": ["person/alice"],
+            },
+        )
+        assert res.status_code == 200, res.text
+        fm = _frontmatter(res.json()["file_path"])
+        assert "project/palinode" in fm["entities"]
+        assert "person/alice" in fm["entities"]
+        # Project ref appears exactly once.
+        assert fm["entities"].count("project/palinode") == 1
+
+
+def test_project_dedup_when_entity_already_includes_it(mock_memory_dir):
+    """If ``entities`` already has the project ref, ``project`` is a no-op."""
+    with patch("palinode.core.store.scan_memory_content", return_value=(True, "OK")):
+        res = client.post(
+            "/save",
+            json={
+                "content": "x",
+                "type": "Decision",
+                "project": "palinode",
+                "entities": ["project/palinode"],
+            },
+        )
+        assert res.status_code == 200, res.text
+        fm = _frontmatter(res.json()["file_path"])
+        assert fm["entities"].count("project/palinode") == 1
+
+
+def test_project_optional(mock_memory_dir):
+    """Saves without ``project`` work exactly as before."""
+    with patch("palinode.core.store.scan_memory_content", return_value=(True, "OK")):
+        res = client.post(
+            "/save",
+            json={"content": "x", "type": "Decision", "entities": ["person/alice"]},
+        )
+        assert res.status_code == 200, res.text
+        fm = _frontmatter(res.json()["file_path"])
+        assert fm["entities"] == ["person/alice"]
+
+
+def test_cli_save_passes_project_flag(mock_memory_dir):
+    """The CLI ``--project / -p`` flag forwards the value to the API."""
+    from click.testing import CliRunner
+
+    from palinode.cli.save import save
+
+    with patch("palinode.core.store.scan_memory_content", return_value=(True, "OK")):
+        runner = CliRunner()
+        result = runner.invoke(
+            save,
+            [
+                "--type",
+                "Decision",
+                "-p",
+                "palinode",
+                "test memory body",
+            ],
+        )
+        assert result.exit_code == 0, result.output

--- a/tests/test_scope_chain.py
+++ b/tests/test_scope_chain.py
@@ -113,7 +113,7 @@ def test_resolve_scope_chain_multi_agent(monkeypatch):
 
 def test_resolve_scope_chain_project_passed_by_caller(monkeypatch):
     """The project level comes from the caller (ADR-008 detection), not config env."""
-    cfg = _fresh_config(monkeypatch, env={"PALINODE_MEMBER": "paul"})
+    cfg = _fresh_config(monkeypatch, env={"PALINODE_MEMBER": "alice"})
     a = resolve_scope_chain(cfg, project="palinode")
     b = resolve_scope_chain(cfg, project="other-project")
     assert "project/palinode" in a.as_list()

--- a/tests/test_session_end_dedup.py
+++ b/tests/test_session_end_dedup.py
@@ -1,0 +1,294 @@
+"""Tests for session-end semantic dedup (#126).
+
+Option (a): when ``palinode_session_end`` is called and a recently indexed
+save has near-identical content, skip the individual file write but still
+append to daily/ and the project-status file.
+
+These tests exercise the real DB + helper path (no mocks for the store) and
+patch only the embedder to keep the suite Ollama-free.
+"""
+from __future__ import annotations
+
+import math
+import os
+import time
+from datetime import UTC, datetime, timedelta
+from unittest import mock
+
+import pytest
+
+from palinode.core import store
+from palinode.core.config import config
+
+
+EMBED_DIM = 1024
+
+
+def _normalize(vec: list[float]) -> list[float]:
+    """L2-normalize so cosine similarity equals dot product (matches BGE-M3)."""
+    n = math.sqrt(sum(x * x for x in vec))
+    if n == 0:
+        return vec
+    return [x / n for x in vec]
+
+
+def _orthogonal_embedding(seed: int) -> list[float]:
+    """Make a near-orthogonal unit vector keyed by ``seed`` (deterministic)."""
+    vec = [0.0] * EMBED_DIM
+    # Spread mass across a small set of indices so two different seeds produce
+    # vectors with nearly-zero cosine overlap.
+    primary = seed % EMBED_DIM
+    secondary = (seed * 7 + 3) % EMBED_DIM
+    vec[primary] = 0.9
+    vec[secondary] = 0.4
+    return _normalize(vec)
+
+
+def _matching_embedding() -> list[float]:
+    """A canonical "session content" embedding, shared by both prior + new save."""
+    return _orthogonal_embedding(42)
+
+
+def _index_prior_save(
+    *,
+    file_path: str,
+    slug_id: str,
+    content: str,
+    embedding: list[float],
+    mtime: datetime | None = None,
+) -> None:
+    """Create a markdown file on disk + a chunks/chunks_vec row for it.
+
+    The dedup helper uses file mtime as the recency signal, so we touch the
+    file and (optionally) backdate it via ``os.utime``.
+    """
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    with open(file_path, "w") as f:
+        f.write(content)
+    if mtime is not None:
+        ts = mtime.timestamp()
+        os.utime(file_path, (ts, ts))
+
+    now_iso = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    store.upsert_chunks([{
+        "id": slug_id,
+        "file_path": file_path,
+        "section_id": None,
+        "category": "projects",
+        "content": content,
+        "metadata": {},
+        "created_at": now_iso,
+        "last_updated": now_iso,
+        "embedding": embedding,
+    }])
+
+
+@pytest.fixture(autouse=True)
+def _isolated_env(tmp_path, monkeypatch):
+    """Point config at a fresh tmp directory and init a real SQLite DB.
+
+    No git, no real Ollama; the embedder gets patched per-test so each test
+    can dictate the similarity outcome it wants to assert against.
+    """
+    memory_dir = str(tmp_path)
+    db_path = os.path.join(memory_dir, ".palinode.db")
+    monkeypatch.setattr(config, "memory_dir", memory_dir)
+    monkeypatch.setattr(config, "db_path", db_path)
+    monkeypatch.setattr(config.git, "auto_commit", False)
+    for d in ("projects", "insights", "daily"):
+        os.makedirs(os.path.join(memory_dir, d), exist_ok=True)
+    store.init_db()
+    yield memory_dir
+
+
+def _count_individual_session_files(memory_dir: str) -> int:
+    projects_dir = os.path.join(memory_dir, "projects")
+    if not os.path.isdir(projects_dir):
+        return 0
+    return sum(1 for f in os.listdir(projects_dir) if f.startswith("session-end-"))
+
+
+def test_below_threshold_writes_both_files(_isolated_env):
+    """A recent save on a different topic must NOT trigger dedup — both files written."""
+    memory_dir = _isolated_env
+
+    # Pre-index a save on a totally different topic
+    _index_prior_save(
+        file_path=os.path.join(memory_dir, "projects", "old-topic.md"),
+        slug_id="projects-old-topic",
+        content="Worked on entity normalization rules",
+        embedding=_orthogonal_embedding(1),
+    )
+
+    # The new session-end content is on yet another topic — embeddings disagree
+    fake_new = _orthogonal_embedding(99)
+
+    with (
+        mock.patch("palinode.core.embedder.embed", return_value=fake_new),
+        mock.patch("palinode.api.server._generate_description", return_value="Different topic"),
+    ):
+        from palinode.api.server import session_end_api, SessionEndRequest
+
+        req = SessionEndRequest(
+            summary="Shipped semantic dedup for session-end",
+            project="palinode",
+            source="test",
+        )
+        result = session_end_api(req)
+
+    # Both files written; no dedup metadata in response
+    assert result.get("individual_file") is not None
+    assert os.path.exists(result["individual_file"])
+    assert "deduplicated_against" not in result
+    daily_path = os.path.join(memory_dir, result["daily_file"])
+    assert os.path.exists(daily_path)
+    assert _count_individual_session_files(memory_dir) == 1
+
+
+def test_above_threshold_skips_individual_file(_isolated_env):
+    """A recent near-identical save MUST suppress the individual file write."""
+    memory_dir = _isolated_env
+
+    matching = _matching_embedding()
+
+    # Pre-index a prior save with the matching embedding
+    _index_prior_save(
+        file_path=os.path.join(memory_dir, "projects", "earlier-snapshot.md"),
+        slug_id="projects-earlier-snapshot",
+        content="Earlier snapshot of the same work",
+        embedding=matching,
+    )
+
+    # Pre-create the project status file so we can verify its append still happens
+    status_path = os.path.join(memory_dir, "projects", "palinode-status.md")
+    with open(status_path, "w") as f:
+        f.write("# palinode status\n")
+
+    with (
+        mock.patch("palinode.core.embedder.embed", return_value=matching),
+        mock.patch("palinode.api.server._generate_description", return_value="Reformatted"),
+    ):
+        from palinode.api.server import session_end_api, SessionEndRequest
+
+        req = SessionEndRequest(
+            summary="Same content, reformatted by session-end",
+            project="palinode",
+            source="test",
+        )
+        result = session_end_api(req)
+
+    # Individual file suppressed
+    assert result.get("individual_file") is None
+    assert _count_individual_session_files(memory_dir) == 0
+    # Response carries the matched slug
+    assert result.get("deduplicated_against") == "projects-earlier-snapshot"
+    # Daily note still appended
+    daily_path = os.path.join(memory_dir, result["daily_file"])
+    assert os.path.exists(daily_path)
+    assert "Same content, reformatted" in open(daily_path).read()
+    # Project status file still appended
+    status_text = open(status_path).read()
+    assert "Same content, reformatted" in status_text
+
+
+def test_above_threshold_outside_window_does_not_dedup(_isolated_env):
+    """An old save (outside the lookback window) must not trigger dedup."""
+    memory_dir = _isolated_env
+
+    matching = _matching_embedding()
+
+    # File mtime two hours ago — outside the default 60-minute window
+    long_ago = datetime.now(UTC) - timedelta(hours=2)
+    _index_prior_save(
+        file_path=os.path.join(memory_dir, "projects", "old-snapshot.md"),
+        slug_id="projects-old-snapshot",
+        content="Old snapshot from earlier today",
+        embedding=matching,
+        mtime=long_ago,
+    )
+
+    with (
+        mock.patch("palinode.core.embedder.embed", return_value=matching),
+        mock.patch("palinode.api.server._generate_description", return_value="Fresh save"),
+    ):
+        from palinode.api.server import session_end_api, SessionEndRequest
+
+        req = SessionEndRequest(
+            summary="A fresh session-end after a long break",
+            project="palinode",
+            source="test",
+        )
+        result = session_end_api(req)
+
+    # Both files written; no dedup metadata in response
+    assert result.get("individual_file") is not None
+    assert os.path.exists(result["individual_file"])
+    assert "deduplicated_against" not in result
+    assert _count_individual_session_files(memory_dir) == 1
+
+
+def test_embedder_failure_writes_both_files(_isolated_env):
+    """When the embedder returns empty, dedup is skipped and both files written."""
+    memory_dir = _isolated_env
+
+    # Even with a perfect-match save indexed, an empty embedding means no dedup
+    _index_prior_save(
+        file_path=os.path.join(memory_dir, "projects", "perfect-match.md"),
+        slug_id="projects-perfect-match",
+        content="Same as new",
+        embedding=_matching_embedding(),
+    )
+
+    with (
+        mock.patch("palinode.core.embedder.embed", return_value=[]),
+        mock.patch("palinode.api.server._generate_description", return_value="Empty embed"),
+    ):
+        from palinode.api.server import session_end_api, SessionEndRequest
+
+        req = SessionEndRequest(
+            summary="Should still write because dedup degraded gracefully",
+            project="palinode",
+            source="test",
+        )
+        result = session_end_api(req)
+
+    assert result.get("individual_file") is not None
+    assert os.path.exists(result["individual_file"])
+    assert "deduplicated_against" not in result
+
+
+def test_recent_save_embeddings_skips_daily_files(_isolated_env):
+    """Daily files must be excluded from the dedup candidate list."""
+    memory_dir = _isolated_env
+    matching = _matching_embedding()
+
+    # Daily-style file — should NOT be returned by recent_save_embeddings
+    _index_prior_save(
+        file_path=os.path.join(memory_dir, "daily", "2026-04-26.md"),
+        slug_id="daily-2026-04-26",
+        content="Daily journal entry",
+        embedding=matching,
+    )
+
+    recent = store.recent_save_embeddings(60)
+    slugs = [s for s, _ in recent]
+    assert "daily-2026-04-26" not in slugs
+
+
+def test_recent_save_embeddings_returns_embedding_data(_isolated_env):
+    """Sanity check: stored embeddings round-trip through the helper as floats."""
+    emb = _matching_embedding()
+    _index_prior_save(
+        file_path=os.path.join(_isolated_env, "projects", "x.md"),
+        slug_id="projects-x",
+        content="some content",
+        embedding=emb,
+    )
+    recent = store.recent_save_embeddings(60)
+    assert len(recent) == 1
+    slug, vec = recent[0]
+    assert slug == "projects-x"
+    assert len(vec) == EMBED_DIM
+    # The recovered vector should match the inserted one to within float32 precision
+    delta = max(abs(a - b) for a, b in zip(vec, emb))
+    assert delta < 1e-5

--- a/tests/test_source_surface.py
+++ b/tests/test_source_surface.py
@@ -66,28 +66,87 @@ def test_save_with_mcp_source(mock_memory_dir):
         assert "source: mcp" in content
 
 def test_save_defaults_source_to_cli(mock_memory_dir):
+    """ADR-010 / #167: when --source is not passed, the body field is None
+    (the X-Palinode-Source header carries attribution; the API resolves it).
+    """
     runner = CliRunner()
-    
+
     with patch("palinode.cli._api.api_client.save") as mock_save:
         mock_save.return_value = {"file": "test", "id": "test"}
         result = runner.invoke(save, ["test", "--type", "Insight"])
-        
+
         assert result.exit_code == 0
         mock_save.assert_called_once()
-        assert mock_save.call_args[1]["source"] == "cli"
+        # No --source passed → body source field is None.  The CLI's httpx
+        # Client carries `X-Palinode-Source: cli` so the API sees the
+        # surface attribution via header.
+        assert mock_save.call_args[1]["source"] is None
+
+
+def test_cli_client_sends_source_header():
+    """ADR-010 / #167: the CLI httpx Client must carry X-Palinode-Source: cli
+    so saves without explicit body `source` are still attributed correctly.
+    """
+    from palinode.cli._api import api_client
+    from palinode.core.defaults import SAVE_SOURCE_HEADER
+
+    assert api_client.client.headers.get(SAVE_SOURCE_HEADER) == "cli"
+
+
+def test_save_uses_header_when_body_source_absent(mock_memory_dir):
+    """API resolves source via the X-Palinode-Source header when the body
+    doesn't set one (ADR-010 / #167)."""
+    with patch("palinode.core.store.scan_memory_content", return_value=(True, "OK")):
+        res = client.post(
+            "/save",
+            json={"content": "hdr test", "type": "Insight"},
+            headers={"X-Palinode-Source": "cursor"},
+        )
+        assert res.status_code == 200
+        with open(res.json()["file_path"], "r") as f:
+            content = f.read()
+        assert "source: cursor" in content
+
+
+def test_save_body_source_wins_over_header(mock_memory_dir):
+    """Explicit body `source` beats the header (ADR-010 / #167 precedence)."""
+    with patch("palinode.core.store.scan_memory_content", return_value=(True, "OK")):
+        res = client.post(
+            "/save",
+            json={"content": "win test", "type": "Insight", "source": "explicit"},
+            headers={"X-Palinode-Source": "cursor"},
+        )
+        assert res.status_code == 200
+        with open(res.json()["file_path"], "r") as f:
+            content = f.read()
+        assert "source: explicit" in content
 
 def test_session_end_includes_source(mock_memory_dir):
+    """ADR-010 / #170: CLI now goes through the API. Patch
+    ``api_client.session_end`` to invoke the in-process API handler so
+    the daily-file end-to-end assertion still holds."""
+    from palinode.api.server import session_end_api, SessionEndRequest
+
     runner = CliRunner()
-    
-    with patch("subprocess.run"):
+
+    def _fake_session_end(**kwargs):
+        # Drop None values so the API's pydantic defaults take effect.
+        clean = {k: v for k, v in kwargs.items() if v is not None}
+        # `decisions`/`blockers` come through as [] when no flags passed;
+        # the in-process handler is happy with empty lists.
+        return session_end_api(SessionEndRequest(**clean))
+
+    with patch("palinode.cli._api.api_client.session_end", side_effect=_fake_session_end), \
+         patch("subprocess.run"), \
+         patch("palinode.api.server._generate_description", return_value="t"):
         result = runner.invoke(session_end, ["Tested something", "--source", "claude-code", "--project", "palinode"])
-        assert result.exit_code == 0
-        
+        assert result.exit_code == 0, result.output
+
     from datetime import datetime, timezone
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     daily_file = os.path.join(mock_memory_dir, "daily", f"{today}.md")
-    
+
     with open(daily_file, "r") as f:
         content = f.read()
-        
+
     assert "**Source:** claude-code" in content

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -1,0 +1,299 @@
+"""
+Cross-surface parity test — ADR-010 forcing function.
+
+For every operation in ``palinode.core.parity.REGISTRY``, asserts that each
+non-exempt surface (CLI, MCP, REST API, plugin) exposes the canonical
+parameters with matching names.
+
+Known drift (per the audit on 2026-04-26) is recorded as ``known_drift`` on
+each Operation, with the GitHub issue tracking the fix.  Drift entries are
+reported as ``xfail`` with a ``reason="drift tracked in #N"`` — the test
+*passes* while the drift exists, but as soon as the surface is fixed the
+``known_drift`` entry must be removed (or the test will fail because the
+parameter now appears unexpectedly).
+
+Plugin parity is documented in ``docs/PARITY.md`` but not asserted in v0
+(Python cannot easily introspect TypeBox schemas in ``plugin/index.ts``).
+A plugin-side TypeScript test is a follow-up.
+
+Run: ``pytest tests/test_surface_parity.py -v``
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import typing
+from typing import Any
+
+import click
+import pytest
+from pydantic import BaseModel
+
+from palinode.cli import main as cli_root
+from palinode.core.parity import (
+    REGISTRY,
+    CanonicalParam,
+    Operation,
+    Surface,
+    required_surfaces,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CLI extraction
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _resolve_cli_command(path: str) -> click.Command | None:
+    """Walk dotted/space-separated CLI path to a Click command."""
+    parts = path.replace(".", " ").split()
+    node: click.Command | click.Group = cli_root
+    for part in parts:
+        if not isinstance(node, click.Group):
+            return None
+        node = node.commands.get(part)  # type: ignore[assignment]
+        if node is None:
+            return None
+    return node  # type: ignore[return-value]
+
+
+def _cli_param_names(cmd: click.Command) -> set[str]:
+    """Return the set of canonical param names a Click command exposes.
+
+    Click stores params as ``--foo-bar`` on the CLI but ``foo_bar`` in
+    Python.  We compare against the Python name (which is the canonical
+    form in our registry).  ``--ps`` flags are renamed to their dest
+    (e.g. ``is_ps``) — we map both to ``ps`` for parity purposes.
+    """
+    names: set[str] = set()
+    for param in cmd.params:
+        if isinstance(param, click.Option):
+            # Click's `name` is the dest; `opts` is the surface flag list.
+            # Prefer `name` (canonical Python form).
+            if param.name:
+                names.add(param.name)
+        elif isinstance(param, click.Argument) and param.name:
+            names.add(param.name)
+    # Click uses `is_ps` as the dest for `--ps`; expose under "ps" too.
+    if "is_ps" in names:
+        names.add("ps")
+    # Click uses `memory_type` as the dest for `--type` (avoid keyword
+    # collision); expose under "type" too.
+    if "memory_type" in names:
+        names.add("type")
+    # Click uses `entities` (multiple=True) for `--entity` repeated.  Same
+    # canonical name; nothing to do.
+    return names
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MCP extraction
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_MCP_TOOL_CACHE: dict[str, dict[str, Any]] | None = None
+
+
+def _mcp_tools() -> dict[str, dict[str, Any]]:
+    """Return ``{tool_name: inputSchema}`` for every MCP tool, cached.
+
+    ``palinode.mcp.list_tools`` is async (MCP protocol contract).  We
+    invoke it once via ``asyncio.run`` and cache for all tests.
+    """
+    global _MCP_TOOL_CACHE
+    if _MCP_TOOL_CACHE is None:
+        from palinode.mcp import list_tools as mcp_list_tools
+
+        tools = asyncio.run(mcp_list_tools())
+        _MCP_TOOL_CACHE = {t.name: t.inputSchema for t in tools}
+    return _MCP_TOOL_CACHE
+
+
+def _mcp_param_names(tool_name: str) -> set[str]:
+    schema = _mcp_tools().get(tool_name)
+    if schema is None:
+        return set()
+    props = schema.get("properties", {}) or {}
+    return set(props.keys())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# API extraction
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+# Map ``(method, path)`` → request-body model (or ``None`` for GET-style).
+# We import lazily inside the helper to keep test collection cheap.
+def _api_param_names(method: str, path: str) -> set[str]:
+    """Extract API parameter names from the FastAPI app.
+
+    For POST endpoints with a pydantic body, returns the model's field
+    names.  For GET endpoints, returns the function's keyword arguments
+    (excluding ``request``-shaped helpers).
+    """
+    from palinode.api.server import app  # lazy
+
+    for route in app.routes:
+        route_path = getattr(route, "path", None)
+        route_methods = getattr(route, "methods", set()) or set()
+        if route_path != path or method.upper() not in route_methods:
+            continue
+
+        endpoint = getattr(route, "endpoint", None)
+        if endpoint is None:
+            return set()
+
+        # ``server.py`` uses ``from __future__ import annotations`` so the
+        # raw ``param.annotation`` is a string.  Resolve via ``get_type_hints``
+        # which evaluates the strings against the function's module globals.
+        try:
+            hints = typing.get_type_hints(endpoint)
+        except Exception:
+            hints = {}
+
+        names: set[str] = set()
+        sig = inspect.signature(endpoint)
+        for param_name, param in sig.parameters.items():
+            if param_name in {"request", "self"}:
+                continue
+            ann = hints.get(param_name, param.annotation)
+            if _is_request_helper(ann):
+                continue
+            # Body param: pydantic BaseModel subclass → use its field names
+            if inspect.isclass(ann) and issubclass(ann, BaseModel):
+                names.update(ann.model_fields.keys())
+            else:
+                names.add(param_name)
+        return names
+
+    return set()
+
+
+def _is_request_helper(annotation: Any) -> bool:
+    """Best-effort check for FastAPI ``Request``/``Response`` helpers."""
+    try:
+        from fastapi import Request, Response
+
+        return annotation in (Request, Response)
+    except Exception:
+        return False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Surface dispatch
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _surface_param_names(op: Operation, surface: Surface) -> set[str]:
+    if surface == "cli":
+        if op.cli_command is None:
+            return set()
+        cmd = _resolve_cli_command(op.cli_command)
+        if cmd is None:
+            return set()
+        return _cli_param_names(cmd)
+    if surface == "mcp":
+        if op.mcp_tool is None:
+            return set()
+        return _mcp_param_names(op.mcp_tool)
+    if surface == "api":
+        if op.api_endpoint is None:
+            return set()
+        method, path = op.api_endpoint
+        return _api_param_names(method, path)
+    if surface == "plugin":
+        # Plugin parity is documented in PARITY.md, not asserted in v0.
+        return set()
+    raise AssertionError(f"unknown surface {surface!r}")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Parametrized test
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _flatten_cases() -> list[tuple[Operation, Surface, CanonicalParam]]:
+    cases: list[tuple[Operation, Surface, CanonicalParam]] = []
+    for op in REGISTRY:
+        # v0: skip plugin parity entirely
+        for surface in sorted(required_surfaces(op) - {"plugin"}):
+            for cp in op.canonical_params:
+                cases.append((op, surface, cp))  # type: ignore[arg-type]
+    return cases
+
+
+def _case_id(case: tuple[Operation, Surface, CanonicalParam]) -> str:
+    op, surface, cp = case
+    return f"{op.name}/{surface}/{cp.name}"
+
+
+@pytest.mark.parametrize("case", _flatten_cases(), ids=_case_id)
+def test_canonical_param_present(case: tuple[Operation, Surface, CanonicalParam]) -> None:
+    """Every canonical param appears on every required surface (or is known drift)."""
+    op, surface, cp = case
+    surface_params = _surface_param_names(op, surface)
+    drift_key = (surface, cp.name)
+    if drift_key in op.known_drift:
+        issue = op.known_drift[drift_key]
+        if cp.name in surface_params:
+            # Drift was tracked but the surface now exposes the param — the
+            # known_drift entry should be removed.  Failing here is the point.
+            pytest.fail(
+                f"{op.name}/{surface}: param {cp.name!r} is now present; "
+                f"remove `known_drift[(\"{surface}\", \"{cp.name}\")]` "
+                f"and close issue #{issue}."
+            )
+        pytest.xfail(f"drift tracked in #{issue}")
+
+    assert cp.name in surface_params, (
+        f"{op.name}/{surface}: canonical param {cp.name!r} not exposed "
+        f"(found: {sorted(surface_params)}). "
+        f"If this is intentional drift, add `known_drift[(\"{surface}\", "
+        f"\"{cp.name}\")] = <issue>` on the Operation."
+    )
+
+
+def test_admin_exempt_ops_are_not_in_registry() -> None:
+    """Operations in ADMIN_EXEMPT_OPERATIONS must not also be in REGISTRY.
+
+    The two lists are mutually exclusive: registry = parity-bound,
+    exempt = parity-free.  Confusion here means an admin op is being
+    silently parity-tested.
+    """
+    from palinode.core.parity import ADMIN_EXEMPT_OPERATIONS
+
+    registry_names = {op.name for op in REGISTRY}
+    overlap = registry_names & ADMIN_EXEMPT_OPERATIONS
+    assert not overlap, (
+        f"Operations both in REGISTRY and ADMIN_EXEMPT_OPERATIONS: {overlap}. "
+        "Pick one — exempt = parity-free, registry = parity-bound."
+    )
+
+
+def test_default_keys_resolve() -> None:
+    """Every CanonicalParam.default_key must exist in palinode.core.defaults."""
+    from palinode.core import defaults as defaults_mod
+
+    missing: list[str] = []
+    for op in REGISTRY:
+        for cp in op.canonical_params:
+            if cp.default_key is not None and not hasattr(defaults_mod, cp.default_key):
+                missing.append(f"{op.name}/{cp.name} → defaults.{cp.default_key}")
+    assert not missing, (
+        "Unknown default_key references in parity registry:\n  "
+        + "\n  ".join(missing)
+    )
+
+
+def test_known_drift_references_a_canonical_param() -> None:
+    """``known_drift`` keys must reference a real canonical param name."""
+    bad: list[str] = []
+    for op in REGISTRY:
+        canonical_names = {cp.name for cp in op.canonical_params}
+        for surface, param_name in op.known_drift:
+            if param_name not in canonical_names:
+                bad.append(f"{op.name}: known_drift[({surface!r}, {param_name!r})]")
+    assert not bad, (
+        "known_drift entries reference unknown params:\n  "
+        + "\n  ".join(bad)
+    )

--- a/tests/test_timestamp_consistency.py
+++ b/tests/test_timestamp_consistency.py
@@ -1,0 +1,327 @@
+"""
+Regression tests for #191 / #192 / #193 — timestamp-write correctness.
+
+Three related issues, all the same shape: a writer used
+``time.strftime("%Y-%m-%dT%H:%M:%SZ")`` (or ``_utc_now().strftime(...Z)``)
+and produced either local-time-stamped-as-UTC or UTC-without-tz-info-and-
+without-sub-second-precision.
+
+#191 / #192 covered ``save_api``'s ``created_at`` and the watcher's
+``metadata.get("created_at")`` read. #193 extends the cleanup to four
+batch surfaces that write ``last_updated`` (and one ``created_at``):
+
+- ``palinode/ingest/pipeline.py``        — research-file frontmatter
+- ``palinode/consolidation/layer_split.py`` — identity / status / history files
+- ``palinode/migration/mem0_generate.py``  — mem0-imported records
+- ``palinode/migration/openclaw.py``      — openclaw-migrated records
+
+The audit invariant ``grep -rn 'strftime.*Z' palinode/`` must return zero
+non-comment matches after this change.
+"""
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+from palinode.api.server import app
+from palinode.core.config import config
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def mock_memory_dir(tmp_path):
+    old = config.memory_dir
+    config.memory_dir = str(tmp_path)
+    yield str(tmp_path)
+    config.memory_dir = old
+
+
+def _frontmatter(file_path: str) -> dict:
+    with open(file_path, "r") as f:
+        text = f.read()
+    parts = text.split("---", 2)
+    assert len(parts) >= 3, f"no frontmatter in {file_path}: {text[:120]}"
+    return yaml.safe_load(parts[1])
+
+
+# ---- save_api: created_at is correct UTC ISO-8601 ------------------------
+
+
+def test_save_api_writes_timezone_aware_utc_created_at(mock_memory_dir):
+    """``save_api`` writes ``created_at`` as a parseable timezone-aware UTC
+    ISO-8601 string, not local-time-with-Z-suffix.
+    """
+    before = datetime.now(UTC)
+    with patch(
+        "palinode.core.store.scan_memory_content", return_value=(True, "OK")
+    ):
+        res = client.post(
+            "/save",
+            json={"content": "timestamp-regression-191", "type": "Decision"},
+        )
+        assert res.status_code == 200, res.text
+    after = datetime.now(UTC)
+
+    fm = _frontmatter(res.json()["file_path"])
+    raw = fm.get("created_at")
+    assert raw, f"created_at missing from frontmatter: {fm!r}"
+
+    # ``yaml.safe_load`` may parse ISO-8601 strings into a ``datetime`` directly
+    # depending on the library version. Normalize either form.
+    if isinstance(raw, datetime):
+        parsed = raw
+    else:
+        assert isinstance(raw, str), f"unexpected created_at type: {type(raw)!r}"
+        # The new code emits "+00:00"; stay tolerant of "Z" too in case a
+        # producer re-introduces it deliberately.
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+
+    # Must carry tz info — otherwise we are back to the local-time bug.
+    assert parsed.tzinfo is not None, (
+        f"created_at must be timezone-aware (was {raw!r})"
+    )
+    # Must specifically be UTC.
+    assert parsed.utcoffset() == timedelta(0), (
+        f"created_at must be UTC (offset was {parsed.utcoffset()!r}, raw={raw!r})"
+    )
+    # Must be within the test wall-clock window — confirms it's the actual
+    # current time, not a corrupted/stale value. Generous tolerance for
+    # clock skew, slow CI, etc.
+    assert before - timedelta(seconds=5) <= parsed <= after + timedelta(seconds=5), (
+        f"created_at {parsed} not within test window [{before}, {after}]"
+    )
+
+
+# ---- watcher: reads the correct metadata key -----------------------------
+
+
+def test_watcher_populates_created_at_from_frontmatter(tmp_path, monkeypatch):
+    """The watcher's per-file processing reads ``metadata.get('created_at')``
+    and stores it in ``chunks.created_at`` — not ``metadata.get('created')``,
+    which always returned ``""``.
+    """
+    monkeypatch.setattr(config, "memory_dir", str(tmp_path))
+    monkeypatch.setattr(config, "db_path", str(tmp_path / "palinode.db"))
+
+    # Reload-ish: the watcher and store modules cache no relevant state, so
+    # init_db on the new path is enough.
+    from palinode.core import store
+    from palinode.indexer import watcher as watcher_mod
+
+    store.init_db()
+
+    expected_iso = "2026-04-26T12:00:00+00:00"
+    md = (
+        "---\n"
+        "id: insights-regression-191-watcher\n"
+        "category: insights\n"
+        "type: Insight\n"
+        f"created_at: '{expected_iso}'\n"
+        "last_updated: '2026-04-26T12:00:00+00:00'\n"
+        "content_hash: deadbeef\n"
+        "---\n\n"
+        "watcher reads metadata.get('created_at') correctly.\n"
+    )
+    insights_dir = tmp_path / "insights"
+    insights_dir.mkdir()
+    file_path = insights_dir / "regression-191-watcher.md"
+    file_path.write_text(md)
+
+    # Avoid hitting the real embedder backend in tests.
+    handler = watcher_mod.PalinodeHandler()
+    with patch.object(
+        watcher_mod.embedder, "embed", return_value=[0.0] * 1024
+    ):
+        handler._process_file(str(file_path))
+
+    db = store.get_db()
+    try:
+        rows = db.execute(
+            "SELECT created_at FROM chunks WHERE file_path = ?",
+            (str(file_path),),
+        ).fetchall()
+    finally:
+        db.close()
+
+    assert rows, "watcher did not produce any chunk rows"
+    for row in rows:
+        assert row["created_at"] == expected_iso, (
+            f"chunks.created_at={row['created_at']!r}, expected {expected_iso!r} "
+            "— watcher likely read the wrong frontmatter key"
+        )
+
+
+# ---- #193: batch surfaces write timezone-aware UTC ISO-8601 --------------
+#
+# One assertion shape, four invocation paths. Each test invokes the real
+# writer (no mocking of the timestamp call site itself), reads the value
+# back, and asserts:
+#   * non-empty string
+#   * ``datetime.fromisoformat`` parses cleanly
+#   * resulting datetime is timezone-aware
+#   * offset is exactly UTC
+#   * value falls inside the test wall-clock window
+#
+# Generous five-second tolerance covers slow CI / clock skew.
+
+
+def _assert_utc_iso8601(raw, before, after, *, field: str = "value") -> None:
+    """Common assertions for a frontmatter timestamp written by #193 surfaces."""
+    assert raw, f"{field} missing or empty"
+    if isinstance(raw, datetime):
+        parsed = raw
+    else:
+        assert isinstance(raw, str), f"{field}: unexpected type {type(raw)!r}"
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    assert parsed.tzinfo is not None, (
+        f"{field} must be timezone-aware (was {raw!r})"
+    )
+    assert parsed.utcoffset() == timedelta(0), (
+        f"{field} must be UTC (offset was {parsed.utcoffset()!r}, raw={raw!r})"
+    )
+    assert (
+        before - timedelta(seconds=5) <= parsed <= after + timedelta(seconds=5)
+    ), f"{field} {parsed} not within test window [{before}, {after}]"
+
+
+def test_ingest_pipeline_writes_timezone_aware_utc_last_updated(tmp_path, monkeypatch):
+    """``write_research_file`` writes ``last_updated`` as proper UTC ISO-8601."""
+    # ``palinode_dir`` is a read-only alias for ``memory_dir`` — set the
+    # underlying attribute.
+    monkeypatch.setattr(config, "memory_dir", str(tmp_path))
+
+    from palinode.ingest import pipeline
+
+    before = datetime.now(UTC)
+    file_path = pipeline.write_research_file(
+        name="ingest 193 regression",
+        content="body",
+        file_type="text",
+    )
+    after = datetime.now(UTC)
+
+    fm = _frontmatter(file_path)
+    _assert_utc_iso8601(fm.get("last_updated"), before, after, field="last_updated")
+
+
+def test_layer_split_writes_timezone_aware_utc_timestamps(tmp_path):
+    """``split_file`` writes UTC ISO-8601 to identity, status, and history files."""
+    src = tmp_path / "demo.md"
+    # Mix of identity-keyword and status-keyword sections so all three layers
+    # actually get written.
+    src.write_text(
+        "---\n"
+        "id: projects-demo\n"
+        "category: projects\n"
+        "---\n\n"
+        "## Architecture\n\n"
+        "How it fits together.\n\n"
+        "## Current Status\n\n"
+        "What we are doing this week (2026-04-26).\n"
+    )
+
+    from palinode.consolidation import layer_split
+
+    before = datetime.now(UTC)
+    results = layer_split.split_file(str(src))
+    after = datetime.now(UTC)
+
+    # Identity file: last_updated
+    fm_id = _frontmatter(results["identity"])
+    _assert_utc_iso8601(
+        fm_id.get("last_updated"), before, after, field="identity.last_updated"
+    )
+
+    # Status file: last_updated (only present if status_sections is non-empty)
+    assert "status" in results, "status file should have been written"
+    fm_status = _frontmatter(results["status"])
+    _assert_utc_iso8601(
+        fm_status.get("last_updated"), before, after, field="status.last_updated"
+    )
+
+    # History file: created_at (only on first split — history is created empty)
+    assert "history" in results, "history file should have been written"
+    fm_hist = _frontmatter(results["history"])
+    _assert_utc_iso8601(
+        fm_hist.get("created_at"), before, after, field="history.created_at"
+    )
+
+
+def test_mem0_generate_writes_timezone_aware_utc_timestamps(tmp_path, monkeypatch):
+    """``mem0_generate.generate_files`` writes UTC ISO-8601 to last_updated.
+
+    Also verifies ``created_at`` falls back to ``datetime.now(UTC).isoformat()``
+    when the source memory has no ``created_at``.
+    """
+    import json
+
+    monkeypatch.setattr(config, "memory_dir", str(tmp_path))
+
+    # Minimal classified-memory fixture: one memory, no source-side
+    # ``created_at`` so the fallback branch is exercised.
+    classified = [
+        {
+            "type": "Insight",
+            "group": "regression-193",
+            "content": "mem0 generate timestamp fix",
+            "entities": [],
+            "source_agent": "test",
+        }
+    ]
+    migration_dir = tmp_path / "migration"
+    migration_dir.mkdir()
+    (migration_dir / "mem0_classified.json").write_text(json.dumps(classified))
+
+    # The function shells out to git at the end; let it fail silently
+    # (tmp_path is not a repo). The file write happens before that.
+    from palinode.migration import mem0_generate
+
+    before = datetime.now(UTC)
+    mem0_generate.generate_files()
+    after = datetime.now(UTC)
+
+    written = tmp_path / "insights" / "regression-193.md"
+    assert written.exists(), f"mem0_generate did not write expected file: {written}"
+
+    fm = _frontmatter(str(written))
+    _assert_utc_iso8601(
+        fm.get("last_updated"), before, after, field="last_updated"
+    )
+    # ``created_at`` came from the fallback (no source ``created_at`` in fixture)
+    _assert_utc_iso8601(
+        fm.get("created_at"), before, after, field="created_at (fallback)"
+    )
+
+
+def test_openclaw_migration_writes_timezone_aware_utc_last_updated(
+    tmp_path, monkeypatch
+):
+    """``openclaw.run_migration`` stamps ``last_updated`` as UTC ISO-8601."""
+    monkeypatch.setattr(config, "memory_dir", str(tmp_path))
+
+    source = tmp_path / "MEMORY.md"
+    source.write_text(
+        "## Demo openclaw section\n\n"
+        "This is an insight worth importing.\n"
+    )
+
+    from palinode.migration import openclaw
+
+    before = datetime.now(UTC)
+    result = openclaw.run_migration(str(source))
+    after = datetime.now(UTC)
+
+    assert result["files_created"], (
+        f"openclaw migration produced no files: {result!r}"
+    )
+    written = os.path.join(tmp_path, result["files_created"][0])
+    fm = _frontmatter(written)
+    _assert_utc_iso8601(
+        fm.get("last_updated"), before, after, field="last_updated"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "palinode"
-version = "0.7.0"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Public sync for the `v0.7.3` release.

This pulls the current shippable dev-main changes into the public repo and finishes the release-specific metadata work:
- bumps package metadata to `0.7.3`
- turns the current changelog `Unreleased` block into a `0.7.3` section
- adds the missing ADR-010 cross-surface-monopoly release note
- ships the search-quality cluster, session-end semantic dedup, timestamp consistency fixes, parity hardening, new docs, and sample-memory fixes

## Validation

- `./scripts/check-shipping-leaks.sh`
- `/Users/admin/Code/palinode-dev/.venv/bin/python -m pytest -q tests/` (`424 passed`)
- fresh venv install: `pip install /tmp/palinode-public` then `palinode --version` -> `0.7.3`

## Notes

- No public issue triage in this PR; release sync first, triage after.
- ADR files, `.claude`, `artifacts/`, and other dev-only paths were kept out of the public sync.