### PR TITLE
docs: scrub public roadmap and release wording

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,7 +36,7 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ## [0.7.2] — 2026-04-26
 
-Bug-fix release with small UX additions. Brings the public repo up to date with two production-impacting fixes (MCP array coercion, SessionEnd hook reasoning) plus search filters and structured session metadata. v0.8.0 remains reserved for Signed Provenance.
+Bug-fix release with small UX additions. Brings the public repo up to date with two production-impacting fixes (MCP array coercion, SessionEnd hook reasoning) plus search filters and structured session metadata. v0.8.0 remains reserved for a later major feature release.
 
 ### Added
 
@@ -60,7 +60,7 @@ Bug-fix release with small UX additions. Brings the public repo up to date with 
 
 ### Tests
 
-- 325 tests passing on dev main (290 on the public-shipped subset; the 35 difference is reverted Phase-B actor-class and capabilities tests not part of this release).
+- 325 tests passing at release time.
 
 ---
 

--- a/docs/MILESTONES.md
+++ b/docs/MILESTONES.md
@@ -30,9 +30,9 @@ Improve what gets stored and how it evolves. Epistemic markers (fact vs inferenc
 
 Bring existing knowledge in. Generic markdown import, Obsidian integration (research stage — palinode is markdown-first by design, the substrate is already compatible), GitLab-aware entity linking, team scopes / agent-to-agent channels, OpenClaw profile migration.
 
-### M5 — Cloud + Signed Provenance
+### M5 — Cloud + Team Sharing
 
-Team sharing, hosted deployment, provenance bridge. Cloud infrastructure with enforced RBAC, monorepo structure for a `palinode_cloud/` package, and Ed25519 signed provenance receipts. This milestone is currently paused pending IP-hygiene clearance; the bridge plan is tracked separately.
+Hosted deployment, shared memory for teams, and the operational foundation for managed use cases. This milestone covers the path from single-user local workflows to collaborative and hosted environments.
 
 ### M6 — v1.0 Packaging
 
@@ -40,7 +40,7 @@ Homebrew, Nix, Mintlify docs site, package architecture restructure. Unblocked w
 
 ### M7 — Research + Speculative
 
-Things worth thinking about that aren't yet committed: query-time delta compilation, prompt A/B testing, Cowork integration, multimodal embeddings (image/PDF), model step-change preparation, Palinode self-tracking, GrueBrain memory pathway rationalization.
+Things worth thinking about that aren't yet committed: query-time delta compilation, prompt A/B testing, Cowork integration, multimodal embeddings (image/PDF), model step-change preparation, Palinode self-tracking, and rationalizing legacy memory workflows.
 
 ## Order rationale
 
@@ -54,7 +54,7 @@ M1 (foundation) → M2 (intelligence) → M3 (quality) → M4 (ecosystem) → M5
 - **M2 next.** The largest leverage point once foundation is solid is "make sessions actually smart" — handoff tokens, scope chains, parity contract enforcement.
 - **M3 third.** Memory quality builds on the agent-intelligence APIs (you need the surfaces before you refine what flows through them).
 - **M4 fourth.** Ecosystem integrations (Obsidian, GitLab, generic markdown import) work best on a stable, intelligent core. *Note: M4's research-stage items can begin in parallel with M1 — different code areas, different audiences, no conflict.*
-- **M5/M6 productization.** Cloud and packaging assume the underlying product is solid. Order between them is parallel-safe; M5 has external dependencies around signed-provenance clearance that affect timing.
+- **M5/M6 productization.** Cloud and packaging assume the underlying product is solid. Order between them is parallel-safe; hosted and team-sharing work also carries additional product and deployment dependencies that affect timing.
 - **M7 last.** Research items inform future direction but don't block shipping.
 
 ## How to contribute


### PR DESCRIPTION
## Summary

Narrow public-docs cleanup for over-specific wording that should not have shipped in the roadmap/release docs.

### Changes
- neutralize `docs/MILESTONES.md` M5 from feature/implementation/legal-review language to generic cloud/team-sharing language
- remove the `GrueBrain` reference from `docs/MILESTONES.md`
- soften two over-specific lines in `docs/CHANGELOG.md`

## Validation

- targeted audit search for the flagged terms
- `./scripts/check-shipping-leaks.sh`

## Scope

Docs-only cleanup. No code changes, no issue triage.