### PR TITLE
[codex] fix(packaging): ship diagnostics modules in v0.8.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ## Unreleased
 
+## [0.8.1] — 2026-04-27
+
+### Fixed
+
+- PyPI packaging now includes the `palinode.diagnostics` packages introduced in `v0.8.0`, so the published distribution contains the full `palinode doctor` implementation.
+
 ## [0.8.0] — 2026-04-27
 
 ### Changed

--- a/docs/RELEASE-NOTES-v0.8.1.md
+++ b/docs/RELEASE-NOTES-v0.8.1.md
@@ -1,0 +1,21 @@
+# palinode v0.8.1 — Packaging Hotfix
+
+**Release date:** 2026-04-27
+**Previous:** v0.8.0 (2026-04-27)
+
+This is a small packaging hotfix release.
+
+## Fixed
+
+- The PyPI package now includes the `palinode.diagnostics` modules added in `v0.8.0`.
+- This ensures `palinode doctor` and its supporting diagnostics code are present in the published distribution, not just the GitHub source tree.
+
+## Upgrade
+
+```bash
+pip install --upgrade palinode
+```
+
+## Full changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for the full release history.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palinode"
-version = "0.8.0"
+version = "0.8.1"
 description = "The memory substrate for AI agents and developer tools. Git-versioned, file-native, MCP-first."
 authors = [
   {name = "Paul Kyle", email = "paul@phasespace.co"}
@@ -72,4 +72,15 @@ markers = [
 asyncio_mode = "strict"
 
 [tool.setuptools]
-packages = ["palinode", "palinode.core", "palinode.indexer", "palinode.api", "palinode.ingest", "palinode.consolidation", "palinode.migration", "palinode.cli"]
+packages = [
+    "palinode",
+    "palinode.api",
+    "palinode.cli",
+    "palinode.consolidation",
+    "palinode.core",
+    "palinode.diagnostics",
+    "palinode.diagnostics.checks",
+    "palinode.indexer",
+    "palinode.ingest",
+    "palinode.migration",
+]


### PR DESCRIPTION
## Summary

This hotfix corrects the published package contents for the v0.8.x line.

Changes:
- bump package version to `0.8.1`
- include `palinode.diagnostics` and `palinode.diagnostics.checks` in the setuptools package list
- add a short `v0.8.1` changelog entry and release notes

## Why

`v0.8.0` added the new `palinode doctor` implementation under `palinode.diagnostics`, but those packages were not included in the hard-coded setuptools package list. A PyPI publish from `v0.8.0` would therefore ship an incomplete distribution.

## Validation

- built sdist and wheel locally with `python -m build --sdist --wheel`
- confirmed the build output contains `palinode/diagnostics/` and `palinode/diagnostics/checks/`
- `twine check dist/*`
- clean-venv smoke install of `palinode-0.8.1-py3-none-any.whl`
- verified `import palinode.diagnostics.checks.memory_dir`

## Release

After merge, cut GitHub release `v0.8.1` and publish the built package to PyPI.