### PR TITLE
[codex] ci: add PyPI trusted publishing workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,54 @@
+name: Publish PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  build-dists:
+    name: Build distributions
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build twine
+          python -m build
+          python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build-dists
+    environment:
+      name: pypi
+      url: https://pypi.org/p/palinode
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -8,6 +8,33 @@ category: documentation
 This document covers the local development workflow, including running the test
 suite and the specific setup required when working inside a `git worktree`.
 
+## PyPI publishing
+
+Palinode publishes to PyPI via GitHub Actions Trusted Publishing.
+
+The repository workflow is `.github/workflows/publish-pypi.yml`. It:
+
+- builds the sdist and wheel on tag pushes matching `v*`
+- runs `twine check` on the built artifacts
+- publishes to PyPI from a separate job using OIDC, without a stored API token
+
+### One-time PyPI setup
+
+PyPI must be configured to trust this repository and workflow.
+
+For the `palinode` project on PyPI:
+
+1. Open **Manage** -> **Publishing**
+2. Add a **GitHub Actions** trusted publisher
+3. Use:
+   - Owner: `phasespace-labs`
+   - Repository name: `palinode`
+   - Workflow name: `publish-pypi.yml`
+   - Environment name: `pypi`
+
+The environment name is optional in PyPI's model, but this repo uses it on
+purpose so GitHub environment protection rules can gate real releases.
+
 ## Basic setup
 
 ```bash


### PR DESCRIPTION
## Summary

Add GitHub Actions Trusted Publishing for PyPI releases.

Changes:
- add `.github/workflows/publish-pypi.yml`
- build sdist/wheel in one job and publish in a separate OIDC-backed job
- document the one-time PyPI trusted-publisher setup in `docs/DEVELOPMENT.md`

## Behavior

- triggers on tag pushes matching `v*`
- also supports `workflow_dispatch`
- uses the GitHub environment `pypi`
- publishes with `pypa/gh-action-pypi-publish@release/v1`

## One-time external setup

PyPI still needs a trusted publisher configured for:
- owner: `phasespace-labs`
- repo: `palinode`
- workflow: `publish-pypi.yml`
- environment: `pypi`