### PR TITLE
release: sync public v0.8.6

### DIFF
--- a/PROGRAM.md
+++ b/PROGRAM.md
@@ -188,7 +188,7 @@ What's stuck and why. (Clear this when resolved.)
 ## Key Decisions
 Link to decision files or inline summaries of major architectural/creative choices.
 - [decision/langgraph-adoption] — why LangGraph
-- [decision/port-dont-rewrite] — ADR-070
+- [decision/port-dont-rewrite] — why the port changed
 
 ## Lessons Learned
 Things this project has taught us. (Fed by consolidation from insights.)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ## Unreleased
 
-## [0.8.5] — 2026-04-28
+## [0.8.6] — 2026-04-29
 
 ### Added
 
+- `pyproject.toml` bumped to **v0.8.6** and `[tool.setuptools] packages` list corrected: `palinode.diagnostics`, `palinode.diagnostics.checks`, `palinode.import_`, and `palinode.lint` were missing and would have been silently omitted from the wheel. All declared packages now match on-disk layout.
+- `palinode mcp-config --diagnose` now covers **Roo Cline** (`rooveterinaryinc.roo-cline`) in addition to the original Cline extension. Roo Cline uses a different extension ID and settings filename (`mcp_settings.json` instead of `cline_mcp_settings.json`).
+- `docs/MCP-INSTALL-RECIPES.md` — new **JetBrains AI Assistant** section (section 6): stdio and HTTP snippets, settings UI path, Settings Sync note, troubleshooting table. Covers IntelliJ IDEA, PyCharm, WebStorm, GoLand, Rider, CLion, DataGrip, RubyMine.
+- `docs/MCP-INSTALL-RECIPES.md` — transport quick reference expanded into a "which transport?" decision block with use-when guidance.
+- `docs/MCP-CONFIG-HOMES.md` — JetBrains section added (UI-first, version-specific path caveat) and Roo Cline paths added. Closes public #24.
 - `tests/integration/test_mcp_e2e.py` — E2E test suite for the MCP client flow: exercises every major MCP tool (search, save, session_end, status, read, history, doctor, list) via in-process FastAPI dispatch with no Ollama required (#122).
 - `tests/integration/test_security.py` — Security test suite covering OWASP top-10: path traversal, null bytes, symlink escape, SQL injection, SSRF, CORS enforcement, rate limiting, request size limit, no stack traces, YAML injection, CRLF header injection, and XSS/script injection (#123).
 - `palinode_cluster_neighbors` / `palinode cluster-neighbors` / `POST /cluster-neighbors` — given a memory file path, returns the top-K semantically related files that are NOT already wikilinked to or from it; surfaces implicit relationships for the LLM to propose new cross-links (#235).
@@ -42,6 +47,7 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- `palinode init` HOOK_SCRIPT (the scaffolded SessionEnd hook) now uses `jq -s` slurp extraction for both MSG_COUNT and FIRST_PROMPT, eliminating the SIGPIPE class entirely. #257 fixed the same bug pattern in `examples/hooks/palinode-session-end.sh` but the scaffolded version in `palinode/cli/init.py` was missed; #267 closes that gap so `palinode init` produces a non-buggy hook on fresh installs.
 - Default `audit.log_path` is now resolved to an absolute path under `memory_dir` at config load time, eliminating the spurious `audit_log_writable` doctor warning on every fresh install (#254).
 - `mcp_config_homes` doctor check no longer reports a misleading "run \`palinode init\`" message when palinode is running over SSH stdio — detects `SSH_CONNECTION` and returns an informational result explaining the remote context (#255).
 - `0.0.0.0` binding warning is now suppressed when `PALINODE_API_BIND_INTENT=public` is set, allowing intentional network-exposed deployments (e.g., Tailscale) to start quietly. The systemd API service template sets this by default (#253).

--- a/docs/MCP-CONFIG-HOMES.md
+++ b/docs/MCP-CONFIG-HOMES.md
@@ -82,6 +82,16 @@ JSON shape: `{ "mcpServers": { "palinode": { ... } } }` — same as Claude Deskt
 | Linux | `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
 | Windows | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json` |
 
+### Roo Cline (VS Code extension — fork of Cline)
+
+Roo Cline uses a different extension ID (`rooveterinaryinc.roo-cline`) and a different settings filename (`mcp_settings.json`). Same JSON shape as Cline.
+
+| Platform | Path |
+|----------|------|
+| macOS | `~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json` |
+| Linux | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json` |
+| Windows | `%APPDATA%\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json` |
+
 ### Zed
 
 Zed stores MCP servers under the `context_servers` key in its settings file — **not** `mcpServers`.
@@ -92,6 +102,23 @@ JSON shape: `{ "context_servers": { "palinode": { ... } } }`.
 | macOS (primary) | `~/.config/zed/settings.json` |
 | macOS (older builds fallback) | `~/Library/Application Support/Zed/settings.json` |
 | Linux | `~/.config/zed/settings.json` |
+
+### JetBrains IDEs (AI Assistant)
+
+JetBrains does not use a hand-edited file with a fixed path. MCP servers are
+configured via the IDE settings UI:
+
+**Settings → Tools → AI Assistant → Model Context Protocol (MCP)**
+
+The underlying config directory varies by product and version
+(`~/Library/Application Support/JetBrains/<Product><Version>/` on macOS,
+`~/.config/JetBrains/<Product><Version>/` on Linux). Use the settings panel
+rather than editing the directory directly. `palinode mcp-config --diagnose`
+does not cover JetBrains for this reason — verify the connection status in
+the IDE's MCP settings panel instead.
+
+Available in IntelliJ IDEA, PyCharm, WebStorm, GoLand, Rider, CLion, DataGrip,
+and RubyMine. Requires AI Assistant 2025.1+ (bundled in 2025.2).
 
 ### Other clients
 

--- a/docs/MCP-INSTALL-RECIPES.md
+++ b/docs/MCP-INSTALL-RECIPES.md
@@ -15,18 +15,29 @@ reports which ones contain a `palinode` entry. See
 
 ---
 
-## Transport quick reference
+## Which transport should I use?
 
-| Transport | Best for | Key field |
-|-----------|----------|-----------|
-| **stdio** | Palinode installed on the same machine as the IDE | `"command": "palinode-mcp"` |
-| **Streamable HTTP** | Palinode on a remote server, or any IDE that supports it | `"url": "http://host:6341/mcp/"` |
+| Transport | Config field | Use when |
+|-----------|-------------|----------|
+| **stdio** | `"command": "palinode-mcp"` | Palinode is installed on the **same machine** as the IDE |
+| **Streamable HTTP** | `"url": "http://host:6341/mcp/"` | Palinode runs on a **remote server** (homelab, VPS, dev box), or when multiple IDEs or team members share one instance |
 
-For remote HTTP setups, start `palinode-mcp-sse` *(serves streamable-HTTP at
-`/mcp/` — name is historical)* on the server before configuring the client.
-Clients should use `"type": "http"` (not `"type": "sse"`) and always include
-the trailing slash: `"url": "http://host:6341/mcp/"`. For stdio, `palinode-mcp`
-must be on PATH (`which palinode-mcp`).
+**Use stdio if:**
+- You ran `pip install palinode` on your laptop and want a single-user local setup.
+- `which palinode-mcp` prints a path.
+
+**Use HTTP if:**
+- Palinode lives on a separate machine and you connect over a network.
+- Multiple IDEs or team members should share the same memory store.
+- You want to switch IDEs without re-configuring the server.
+
+For HTTP setups, start `palinode-mcp-sse` on the server first (despite the
+name, it serves Streamable HTTP at `/mcp/`). Always include the trailing slash
+in the URL. Confirm the server is reachable before editing the IDE config:
+
+```bash
+curl http://your-server:6341/mcp/
+```
 
 ---
 
@@ -266,12 +277,21 @@ palinode mcp-config --diagnose
 
 ---
 
-## 4. Cline (VS Code)
+## 4. Cline / Roo Cline (VS Code)
 
-**Docs verified:** [docs.cline.bot/mcp/configuring-mcp-servers](https://docs.cline.bot/mcp/configuring-mcp-servers)
+**Cline docs:** [docs.cline.bot/mcp/configuring-mcp-servers](https://docs.cline.bot/mcp/configuring-mcp-servers)
 
-Cline stores MCP server config in a per-extension settings file whose path
-varies by platform:
+Both Cline and its fork **Roo Cline** use the same `mcpServers` JSON shape.
+They differ only in extension ID, config file path, and filename — pick the
+table row that matches the extension you have installed.
+
+> **Which extension do you have?** In VS Code, open the Extensions sidebar
+> (`Cmd+Shift+X` / `Ctrl+Shift+X`) and search "cline". The publisher field
+> confirms the fork: **saoudrizwan** = Cline, **RooVeterinaryInc** = Roo Cline.
+
+### Config file paths
+
+**Cline** (`saoudrizwan.claude-dev`) — file: `cline_mcp_settings.json`
 
 | Platform | Path |
 |----------|------|
@@ -279,15 +299,29 @@ varies by platform:
 | Linux | `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` |
 | Windows | `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json` |
 
-The easiest way to open the file is from within VS Code:
+**Roo Cline** (`rooveterinaryinc.roo-cline`) — file: `mcp_settings.json`
 
-1. Open the Cline sidebar.
-2. Click the **MCP Servers** icon (plug icon) in Cline's top navigation bar.
+| Platform | Path |
+|----------|------|
+| macOS | `~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json` |
+| Linux | `~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json` |
+| Windows | `%APPDATA%\Code\User\globalStorage\rooveterinaryinc.roo-cline\settings\mcp_settings.json` |
+
+The easiest way to open the file without navigating manually:
+
+1. Click the extension's icon in the VS Code Activity Bar to open its sidebar.
+2. Click the **MCP Servers** icon (plug icon) in the top navigation bar.
 3. Select the **Installed** tab.
-4. Click **Configure MCP Servers** — this opens `cline_mcp_settings.json`
+4. Click **Configure MCP Servers** — this opens the correct settings file
    directly in the editor.
 
+> **Note:** the settings file does not exist until you open the MCP settings
+> panel at least once. Use the UI path above to let the extension create it
+> before editing.
+
 ### stdio (local install)
+
+Use this when Palinode is installed on the same machine as VS Code.
 
 ```json
 {
@@ -307,9 +341,9 @@ The easiest way to open the file is from within VS Code:
 
 ### HTTP (remote server)
 
-Cline uses `"url"` for remote MCP endpoints. `palinode-mcp-sse` serves
-streamable-HTTP at `/mcp/` (the binary name is historical). Always include
-the trailing slash in the URL:
+Use this when Palinode runs on a separate machine. Both forks use `"url"` for
+the HTTP endpoint. `palinode-mcp-sse` serves streamable-HTTP at `/mcp/` (the
+binary name is historical). Always include the trailing slash:
 
 ```json
 {
@@ -323,15 +357,23 @@ the trailing slash in the URL:
 }
 ```
 
+Replace `your-server` with your server's hostname or IP (`localhost` for a
+local HTTP server, or a stable hostname / IP for remote). Confirm the MCP
+server is reachable before configuring the client:
+
+```bash
+curl http://your-server:6341/mcp/
+```
+
 ### Restart sequence
 
-Cline picks up config changes without a VS Code restart. After saving
-`cline_mcp_settings.json`:
+Both forks pick up config changes without a VS Code restart:
 
-1. Return to the Cline sidebar → MCP Servers tab.
-2. The `palinode` entry should appear. If it shows an error badge, click
+1. Save the settings file.
+2. Return to the extension sidebar → **MCP Servers** tab.
+3. The `palinode` entry should appear. If it shows an error badge, click
    **Restart Server**.
-3. No full VS Code restart is needed.
+4. No full VS Code restart is needed.
 
 ### Verification
 
@@ -339,26 +381,52 @@ Cline picks up config changes without a VS Code restart. After saving
 palinode mcp-config --diagnose
 ```
 
-The diagnose command does not currently know Cline's globalStorage path; it
-will not report this file. Instead, verify directly in the Cline sidebar —
-the server should show as connected (green) and the tool list should expand
-to show all palinode tools.
+The diagnose command knows both Cline and Roo Cline paths — it will report
+whichever file is present. Also verify in the sidebar: the server should show
+as connected (green) and the tool list should expand to show all palinode tools.
 
-Then in a Cline conversation:
+Then in a conversation with the extension:
 
 ```
 Use palinode_status to check memory health
 ```
 
+### Reducing approval prompts
+
+Both forks prompt for approval on every MCP tool call by default. To
+pre-approve the tools you use most often, add their names to `alwaysAllow`:
+
+```json
+{
+  "mcpServers": {
+    "palinode": {
+      "url": "http://your-server:6341/mcp/",
+      "disabled": false,
+      "alwaysAllow": [
+        "palinode_search",
+        "palinode_save",
+        "palinode_status",
+        "palinode_read",
+        "palinode_list",
+        "palinode_history"
+      ]
+    }
+  }
+}
+```
+
+See [MCP-SETUP.md](MCP-SETUP.md) for the full tool list.
+
 ### Troubleshooting
 
 | Symptom | Fix |
 |---------|-----|
-| Server shows error badge immediately | `palinode-mcp` not found on PATH. Set `"command"` to the absolute path: open a VS Code terminal, activate your palinode venv, run `which palinode-mcp` |
-| `cline_mcp_settings.json` not found | The file does not exist until you open Cline's MCP settings at least once. Use the UI path above to let Cline create it |
-| Tools appear but all fail | Palinode API not running. Run `curl http://127.0.0.1:6340/status` from a terminal |
-| HTTP: `url` field ignored | Confirm the key is lowercase `"url"` — Cline does not accept `serverUrl` |
-| `alwaysAllow` prompts every tool call | Add the tool names to the `alwaysAllow` array: `["palinode_search", "palinode_save", "palinode_status"]` |
+| Server shows error badge immediately | `palinode-mcp` not found on PATH. Open a VS Code terminal, activate your palinode venv, run `which palinode-mcp` — use that absolute path as `"command"` |
+| Settings file not found | Open the MCP settings panel from the extension UI (step 4 above) to let the extension create it, then edit |
+| Tools appear but all fail | Palinode API not running. `curl http://127.0.0.1:6340/status` should return JSON |
+| HTTP: `url` field ignored | Confirm the key is lowercase `"url"` — neither fork accepts `serverUrl` |
+| HTTP: cannot connect to remote | Confirm `palinode-mcp-sse` is running on the server: `curl http://your-server:6341/mcp/` |
+| Wrong file edited — change had no effect | Run `palinode mcp-config --diagnose` to see which file your installed extension reads |
 
 ---
 
@@ -455,9 +523,84 @@ Use palinode_status to check memory health
 
 ---
 
+## 6. JetBrains IDEs (AI Assistant)
+
+**Docs:** [jetbrains.com/help/ai-assistant/configure-an-mcp-server.html](https://www.jetbrains.com/help/ai-assistant/configure-an-mcp-server.html)
+
+The MCP client is built into the **AI Assistant** plugin, available in
+IntelliJ IDEA, PyCharm, WebStorm, GoLand, Rider, CLion, DataGrip, and
+RubyMine. It is bundled in 2025.2+; for 2025.1 install the AI Assistant
+plugin from the marketplace.
+
+> **JetBrains is UI-first.** MCP servers are configured via the IDE settings
+> panel, not a hand-edited file. The underlying config directory varies by
+> product and version — use the UI path below rather than editing files
+> directly.
+
+### Add via settings UI
+
+1. Open **Settings** (`Cmd+,` on macOS / `Ctrl+Alt+S` on Windows/Linux).
+2. Navigate to **Tools → AI Assistant → Model Context Protocol (MCP)**.
+3. Click **+** (Add) and choose **As JSON**.
+4. Paste the appropriate snippet below.
+5. Click **Apply** — this starts the server immediately. No restart needed.
+
+> **Settings Sync:** If you use JetBrains Settings Sync, the MCP config
+> propagates automatically to all your other JetBrains IDEs.
+
+### stdio (local install)
+
+```json
+{
+  "mcpServers": {
+    "palinode": {
+      "command": "palinode-mcp",
+      "args": [],
+      "env": {
+        "PALINODE_API_HOST": "127.0.0.1",
+        "PALINODE_API_PORT": "6340"
+      }
+    }
+  }
+}
+```
+
+### HTTP (remote server)
+
+```json
+{
+  "mcpServers": {
+    "palinode": {
+      "url": "http://your-server:6341/mcp/"
+    }
+  }
+}
+```
+
+### Verification
+
+After clicking Apply, open the AI Assistant chat panel. In Agent mode, the
+tool list should include all palinode tools. Then run:
+
+```
+Use palinode_status to check memory health
+```
+
+### Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| Server entry saves but tools never appear | Re-open **Settings → Tools → AI Assistant → MCP** and confirm the entry is enabled |
+| stdio server fails immediately | Replace `"command": "palinode-mcp"` with the absolute path returned by `which palinode-mcp` in the same shell environment the IDE inherits |
+| HTTP server fails immediately | Confirm the server is reachable first: `curl http://your-server:6341/mcp/` |
+| Config seems to disappear across IDEs | Check whether JetBrains Settings Sync is enabled and overwriting the MCP entry from another machine |
+| Unsure where the config lives on disk | Use the settings UI; the path is product- and version-specific, which is why `palinode mcp-config --diagnose` does not try to manage it |
+
+---
+
 ## Environment variable reference
 
-All five clients above can pass env vars to the stdio `palinode-mcp` process.
+All six clients above can pass env vars to the stdio `palinode-mcp` process.
 The full variable set:
 
 | Variable | Default | Purpose |

--- a/palinode/cli/init.py
+++ b/palinode/cli/init.py
@@ -110,12 +110,17 @@ fi
 #   user:      {type: "user", message: {role: "user", content: "text"}}
 #   assistant: {type: "assistant", message: {content: [{type: "text", text: "..."}]}}
 #
-# `grep -c '.'` always prints a single integer; `|| true` swallows its
-# non-zero exit on empty match. `:-0` covers a totally empty pipeline.
-# This guards against the bug where empty transcripts produced "0\\n0",
-# breaking the integer test below and letting bogus captures through (#151).
-MSG_COUNT=$(jq -r 'select(.type == "user") | .message.content // empty' \\
-  "$TRANSCRIPT_PATH" 2>/dev/null | grep -c '.' || true)
+# Both extractions use `jq -s` (slurp) so all reductions happen INSIDE jq.
+# Earlier versions piped `jq | head -1` and `jq | grep -c '.'`, which was
+# fragile under `set -o pipefail`: the downstream consumer exits early, the
+# next jq write hits a closed pipe → SIGPIPE → pipefail aborts the script.
+# The MSG_COUNT case was first patched with `|| true` (#151); the
+# FIRST_PROMPT case retained the same fragile shape until #267. Slurping
+# reads JSONL lines into an array; map+filter+slice runs without an
+# early-exit downstream consumer, eliminating the SIGPIPE class entirely.
+# Mirrors examples/hooks/palinode-session-end.sh fix from #257.
+MSG_COUNT=$(jq -r -s 'map(select(.type == "user") | .message.content // empty) | length' \\
+  "$TRANSCRIPT_PATH" 2>/dev/null || echo 0)
 MSG_COUNT=${MSG_COUNT:-0}
 
 # Skip trivial sessions
@@ -124,8 +129,8 @@ if [ "$MSG_COUNT" -lt "$MIN_MESSAGES" ]; then
 fi
 
 PROJECT=$(basename "$CWD" 2>/dev/null || echo "unknown")
-FIRST_PROMPT=$(jq -r 'select(.type == "user") | .message.content // empty' \\
-  "$TRANSCRIPT_PATH" 2>/dev/null | head -1 | cut -c1-200)
+FIRST_PROMPT=$(jq -r -s 'map(select(.type == "user") | .message.content // empty) | .[0] // ""' \\
+  "$TRANSCRIPT_PATH" 2>/dev/null | cut -c1-200)
 
 SUMMARY="Auto-captured (${SOURCE_REASON}, ${MSG_COUNT} messages). Topic: ${FIRST_PROMPT}"
 

--- a/palinode/cli/mcp_config.py
+++ b/palinode/cli/mcp_config.py
@@ -80,6 +80,13 @@ def _candidate_paths() -> list[tuple[str, Path]]:
             / "globalStorage" / "saoudrizwan.claude-dev" / "settings"
             / "cline_mcp_settings.json",
         ))
+        # Roo Cline — fork of Cline, different extension ID and settings filename
+        paths.append((
+            "Roo Cline (macOS) — ~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json",
+            home / "Library" / "Application Support" / "Code" / "User"
+            / "globalStorage" / "rooveterinaryinc.roo-cline" / "settings"
+            / "mcp_settings.json",
+        ))
     elif system == "Windows":
         import os
         appdata = Path(os.environ.get("APPDATA", home / "AppData" / "Roaming"))
@@ -88,12 +95,22 @@ def _candidate_paths() -> list[tuple[str, Path]]:
             appdata / "Code" / "User" / "globalStorage" / "saoudrizwan.claude-dev"
             / "settings" / "cline_mcp_settings.json",
         ))
+        paths.append((
+            "Roo Cline (Windows) — %APPDATA%\\Code\\User\\globalStorage\\rooveterinaryinc.roo-cline\\settings\\mcp_settings.json",
+            appdata / "Code" / "User" / "globalStorage" / "rooveterinaryinc.roo-cline"
+            / "settings" / "mcp_settings.json",
+        ))
     else:
         # Linux
         paths.append((
             "Cline (Linux) — ~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json",
             home / ".config" / "Code" / "User" / "globalStorage"
             / "saoudrizwan.claude-dev" / "settings" / "cline_mcp_settings.json",
+        ))
+        paths.append((
+            "Roo Cline (Linux) — ~/.config/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json",
+            home / ".config" / "Code" / "User" / "globalStorage"
+            / "rooveterinaryinc.roo-cline" / "settings" / "mcp_settings.json",
         ))
 
     # Zed — context_servers block in settings.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "palinode"
-version = "0.8.5"
+version = "0.8.6"
 description = "The memory substrate for AI agents and developer tools. Git-versioned, file-native, MCP-first."
 authors = [
   {name = "Paul Kyle", email = "paul@phasespace.co"}
@@ -72,4 +72,17 @@ markers = [
 asyncio_mode = "strict"
 
 [tool.setuptools]
-packages = ["palinode", "palinode.core", "palinode.indexer", "palinode.api", "palinode.ingest", "palinode.consolidation", "palinode.migration", "palinode.cli"]
+packages = [
+    "palinode",
+    "palinode.api",
+    "palinode.cli",
+    "palinode.consolidation",
+    "palinode.core",
+    "palinode.diagnostics",
+    "palinode.diagnostics.checks",
+    "palinode.import_",
+    "palinode.indexer",
+    "palinode.ingest",
+    "palinode.lint",
+    "palinode.migration",
+]

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -75,32 +75,37 @@ def test_ps_and_wrap_are_different():
     assert PS_COMMAND_BODY != WRAP_COMMAND_BODY
 
 
-# ---- Hook script message-count extraction (#151) ------------------------
+# ---- Hook script slurp-based extraction (#151, #267, mirrors #257) -------
 
 
-def test_hook_script_count_extraction_uses_safe_pattern():
-    """`grep -c` always prints an integer; `|| echo "0"` would double-print
-    on empty match, producing "0\\n0" which broke the integer test in #151.
-    Guard against re-introducing the bug with a string check."""
-    # Old (broken) pattern must be absent
-    assert 'grep -c \'.\' 2>/dev/null || echo "0"' not in HOOK_SCRIPT
-    assert 'grep -c "." 2>/dev/null || echo "0"' not in HOOK_SCRIPT
-    # New pattern must be present (single integer guarantee + safe default)
-    assert "grep -c '.' || true" in HOOK_SCRIPT
+def test_hook_script_uses_slurp_extraction():
+    """Both MSG_COUNT and FIRST_PROMPT must use `jq -s` (slurp) extraction.
+    The earlier piped patterns (`jq | grep -c '.'` and `jq | head -1 | cut`)
+    were fragile under `set -o pipefail`: downstream early-exit triggers
+    SIGPIPE on jq. #151 patched MSG_COUNT with `|| true`; #267 + #257 moved
+    both to slurp, which has no early-exit downstream consumer and thus
+    no SIGPIPE class to swallow. Guard against regression."""
+    # Old fragile patterns must be absent
+    assert "grep -c '.' || true" not in HOOK_SCRIPT
+    assert "head -1 | cut -c1-200)" not in HOOK_SCRIPT
+    assert "head -1 | cut -c1-200 || true" not in HOOK_SCRIPT
+    # New slurp patterns must be present
+    assert "jq -r -s 'map(select(.type == \"user\") | .message.content // empty) | length'" in HOOK_SCRIPT
+    assert "jq -r -s 'map(select(.type == \"user\") | .message.content // empty) | .[0] // \"\"'" in HOOK_SCRIPT
+    # Safe default for MSG_COUNT must remain
     assert "MSG_COUNT=${MSG_COUNT:-0}" in HOOK_SCRIPT
 
 
 def test_hook_script_drops_empty_transcript(tmp_path):
     """Empty transcript ⇒ MSG_COUNT=0 ⇒ filter drops, no save attempted.
-    Behavioral test extracted from the script's exact extraction line, run
-    against a real bash subprocess so any shell-quoting regression is caught."""
+    Exercises the slurp extraction directly to catch shell-quoting regressions."""
     transcript = tmp_path / "empty.jsonl"
     transcript.write_text("")
     snippet = (
         f'set -euo pipefail; '
         f'TRANSCRIPT_PATH={transcript}; '
-        f'MSG_COUNT=$(jq -r \'select(.type == "user") | .message.content // empty\' '
-        f'  "$TRANSCRIPT_PATH" 2>/dev/null | grep -c \'.\' || true); '
+        f'MSG_COUNT=$(jq -r -s \'map(select(.type == "user") | .message.content // empty) | length\' '
+        f'  "$TRANSCRIPT_PATH" 2>/dev/null || echo 0); '
         f'MSG_COUNT=${{MSG_COUNT:-0}}; '
         f'echo "result=$MSG_COUNT"; '
         f'[ "$MSG_COUNT" -lt 3 ] && echo "drops" || echo "saves"'
@@ -126,14 +131,39 @@ def test_hook_script_counts_user_messages_correctly(tmp_path):
     snippet = (
         f'set -euo pipefail; '
         f'TRANSCRIPT_PATH={transcript}; '
-        f'MSG_COUNT=$(jq -r \'select(.type == "user") | .message.content // empty\' '
-        f'  "$TRANSCRIPT_PATH" 2>/dev/null | grep -c \'.\' || true); '
+        f'MSG_COUNT=$(jq -r -s \'map(select(.type == "user") | .message.content // empty) | length\' '
+        f'  "$TRANSCRIPT_PATH" 2>/dev/null || echo 0); '
         f'MSG_COUNT=${{MSG_COUNT:-0}}; '
         f'echo "result=$MSG_COUNT"'
     )
     proc = subprocess.run(["/bin/bash", "-c", snippet], capture_output=True, text=True)
     assert proc.returncode == 0, proc.stderr
     assert "result=5" in proc.stdout
+
+
+def test_hook_script_first_prompt_extracts_correctly(tmp_path):
+    """Multi-message transcript ⇒ FIRST_PROMPT extracts the FIRST user message
+    and survives `set -euo pipefail` cleanly (no SIGPIPE because slurp has
+    no early-exit downstream consumer). Regression guard for #267."""
+    transcript = tmp_path / "multi.jsonl"
+    transcript.write_text(
+        '{"type":"user","message":{"content":"first message — must surface"}}\n'
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"reply"}]}}\n'
+        '{"type":"user","message":{"content":"second"}}\n'
+        '{"type":"user","message":{"content":"third"}}\n'
+        '{"type":"user","message":{"content":"fourth"}}\n'
+        '{"type":"user","message":{"content":"fifth"}}\n'
+    )
+    snippet = (
+        f'set -euo pipefail; '
+        f'TRANSCRIPT_PATH={transcript}; '
+        f'FIRST_PROMPT=$(jq -r -s \'map(select(.type == "user") | .message.content // empty) | .[0] // ""\' '
+        f'  "$TRANSCRIPT_PATH" 2>/dev/null | cut -c1-200); '
+        f'echo "result=$FIRST_PROMPT"'
+    )
+    proc = subprocess.run(["/bin/bash", "-c", snippet], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    assert "result=first message — must surface" in proc.stdout
 
 
 # ---- Hook script reason filter (#149) -----------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "palinode"
-version = "0.7.2"
+version = "0.8.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- sync the public repo to v0.8.6 from palinode-dev origin/main
- fix wheel packaging to include palinode.diagnostics, palinode.diagnostics.checks, palinode.import_, and palinode.lint
- add Roo Cline + JetBrains MCP docs and the transport decision guide
- fix the palinode init SessionEnd hook scaffold to use jq slurp extraction

## Validation
- uv run --extra dev pytest tests/test_cli_init.py tests/test_mcp_config_diagnose.py
- bash scripts/check-shipping-leaks.sh
- editable install check on reconciled dev origin/main (56bc73a)
