### PR TITLE
fix(claims): display partial hash marker in claims resolution output (#66)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -115,6 +115,7 @@ reader before writing new records with v0.10.0.
   warning naming the file, the offending value, and the accepted set, reports
   `layer_hint_ignored` in the `split_file` result, and counts `hints_ignored` in the
   sweep's stats — so a run that fell back to heuristics no longer reports as clean.
+- **Display** `(partial — no stored hash)` marker for claims with `span_partial=True` in `format_claims_resolution` (#66).
 
 ### Removed
 

--- a/palinode/core/claims.py
+++ b/palinode/core/claims.py
@@ -301,6 +301,8 @@ def format_claims_resolution(file_path: str, resolutions: list[dict[str, Any]]) 
             flags.append("claim_id mismatch")
         if not r.get("source_declared", False):
             flags.append("source not in sources[]")
+        if r.get("span_partial", False):
+            flags.append("partial — no stored hash")
         flag_note = f" ({'; '.join(flags)})" if flags else ""
         lines.append(f"[{r.get('span_status', '?')}] {r.get('claim_id', '?')}{flag_note}")
         lines.append(f"  claim:  {r.get('text', '')}")

--- a/tests/test_claims_508.py
+++ b/tests/test_claims_508.py
@@ -558,3 +558,37 @@ def test_cli_save_without_claim_sends_no_claims():
     result, body = _run_cli_save(["--type", "Decision", "plain body"])
     assert result.exit_code == 0, result.output
     assert "claims" not in body
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Partial span marker rendering tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_format_claims_resolution_renders_partial_marker():
+    """Verify that (partial — no stored hash) is rendered when span_partial is True."""
+    text = format_claims_resolution("decisions/claim.md", [{
+        "claim_id": "abc123",
+        "text": "the claim",
+        "source_id": "research/src.md",
+        "span": {"quote": "q"},
+        "span_status": "ok",
+        "claim_id_status": "ok",
+        "source_declared": True,
+        "span_partial": True,
+    }])
+    assert "(partial — no stored hash)" in text
+
+
+def test_format_claims_resolution_omits_partial_marker_when_false():
+    """Verify that (partial — no stored hash) is omitted when span_partial is False."""
+    text = format_claims_resolution("decisions/claim.md", [{
+        "claim_id": "abc123",
+        "text": "the claim",
+        "source_id": "research/src.md",
+        "span": {"quote": "q", "quote_hash": "hash123"},
+        "span_status": "ok",
+        "claim_id_status": "ok",
+        "source_declared": True,
+        "span_partial": False,
+    }])
+    assert "(partial — no stored hash)" not in text


### PR DESCRIPTION
Adds the `(partial — no stored hash)` marker to claims where `span_partial=True` in `format_claims_resolution`. Previously, hash-less claims rendered identically to fully verified ones.

Closes #66