### PR TITLE
fix: enforce canonical enums across surfaces

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -63,6 +63,12 @@ reader before writing new records with v0.10.0.
 
 ### Fixed
 
+- **Surface enums now stay aligned with the canonical parity registry** (#69).
+  CLI, MCP, and REST schemas import the category, memory-type, and prompt-task
+  lists from `palinode/core/parity.py`; the OpenClaw plugin mirrors those values
+  with a cross-language drift test. This restores plural category names,
+  includes `ResearchRef`, and exposes `nightly-consolidation` through the API.
+
 - **`quote_hash` is now algorithm-prefixed, so citation anchors can outlive their hash
   function.** Anchors were written as a bare MD5 hex digest, inherited from the dedup
   hasher. A bare digest records no algorithm, so there was no way to tell MD5 from

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -79,7 +79,9 @@ Singular variants (`person`, `project`, etc.) are **entity-ref prefixes**, not c
 PersonMemory, Decision, ProjectSnapshot, Insight, ResearchRef, ActionItem
 ```
 
-Stored at `palinode/core/parity.py:MEMORY_TYPES`. The plugin's `palinode_save` schema declares `type` (it accepts the enum values as a free-form string today; tightening to a TypeBox `Union` of literal types is the remaining slice of #166).
+Stored at `palinode/core/parity.py:MEMORY_TYPES`. The Python surfaces import
+that tuple directly; the plugin mirrors it as a TypeBox literal union, with the
+cross-language parity test guarding against drift.
 
 ### Prompt tasks — exact set
 

--- a/palinode/api/routers/memory.py
+++ b/palinode/api/routers/memory.py
@@ -6,11 +6,12 @@ import re
 import subprocess
 import time
 import yaml
-from typing import Any
+from typing import Any, Literal
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 from palinode.core import store, git_tools
 from palinode.core.config import config
+from palinode.core.parity import CATEGORIES, MEMORY_TYPES
 from palinode.core.envelope import envelope_complaint
 from palinode.core.scope import ScopeChain
 from palinode.core.visibility import is_visible
@@ -186,7 +187,7 @@ def read_api(file_path: str, meta: bool = False) -> dict[str, Any]:
 
 class SaveRequest(BaseModel):
     content: str
-    type: str
+    type: Literal[*MEMORY_TYPES]
     slug: str | None = None
     entities: list[str] | None = None
     metadata: Any | None = None
@@ -348,7 +349,9 @@ def collect_memory_files(
 
 
 @router.get("/list")
-def list_api(category: str | None = None, core_only: bool = False) -> list[dict[str, Any]]:
+def list_api(
+    category: Literal[*CATEGORIES] | None = None, core_only: bool = False
+) -> list[dict[str, Any]]:
     """Browse memories, newest first.
 
     Never scope-filters (no session chain here — that's /context/prime's job),

--- a/palinode/api/routers/search.py
+++ b/palinode/api/routers/search.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 import os
 import re
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, Literal
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 from palinode.core import store, embedder
 from palinode.core.config import config
+from palinode.core.parity import CATEGORIES, MEMORY_TYPES
 from palinode.api._util import _retrieval_logger, _safe_500
 from palinode.api.rate_limit import _RATE_LIMIT_SEARCH, _check_rate_limit
 from palinode.api.search_helpers import (
@@ -119,7 +120,7 @@ def _fetch_visible(
 
 class SearchRequest(BaseModel):
     query: str
-    category: str | None = None
+    category: Literal[*CATEGORIES] | None = None
     limit: int | None = config.search.default_limit
     threshold: float | None = config.search.api_threshold
     hybrid: bool | None = None
@@ -134,7 +135,7 @@ class SearchRequest(BaseModel):
     # ProjectSnapshot, Insight, ResearchRef, ActionItem). Independent of `category`
     # which filters by directory. Applied as a post-fetch filter; pass multiple
     # types to OR them.
-    types: list[str] | None = None
+    types: list[Literal[*MEMORY_TYPES]] | None = None
     # deny-list complement to `types`. Results whose `type` is in this list
     # are excluded after fetch. Takes precedence: a result present in both `types`
     # and `type_deny` is dropped.

--- a/palinode/api/routers/session.py
+++ b/palinode/api/routers/session.py
@@ -13,7 +13,7 @@ import hashlib
 import logging
 import os
 import re
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
@@ -21,6 +21,7 @@ from pydantic import BaseModel
 from palinode.core import git_tools
 from palinode.core.config import config
 from palinode.core.envelope import envelope_complaint
+from palinode.core.parity import PROMPT_TASKS
 
 from palinode.api._util import _project_from_cwd, _utc_now
 from palinode.api.path_safety import _memory_base_dir
@@ -415,9 +416,6 @@ def session_end_api(req: SessionEndRequest, request: Request = None) -> dict[str
 
 # ── Prompts ──────────────────────────────────────────────────────────────────
 
-PROMPT_TASKS = {"compaction", "extraction", "update", "classification"}
-
-
 def _prompts_dir() -> str:
     return os.path.join(_memory_base_dir(), "prompts")
 
@@ -444,7 +442,9 @@ def _read_prompt_file(file_path: str) -> dict[str, Any]:
 
 
 @router.get("/prompts")
-def list_prompts_api(task: str | None = None) -> list[dict[str, Any]]:
+def list_prompts_api(
+    task: Literal[*PROMPT_TASKS] | None = None,
+) -> list[dict[str, Any]]:
     """List all prompt files, optionally filtered by task."""
     prompts_dir = _prompts_dir()
     if not os.path.exists(prompts_dir):

--- a/palinode/cli/list_cmd.py
+++ b/palinode/cli/list_cmd.py
@@ -1,9 +1,10 @@
 import click
 from palinode.cli._api import api_client
 from palinode.cli._format import console, print_result, get_default_format, OutputFormat
+from palinode.core.parity import CATEGORIES
 
 @click.command()
-@click.option("--category", type=click.Choice(["people", "projects", "decisions", "insights", "research"]))
+@click.option("--category", type=click.Choice(CATEGORIES))
 @click.option("--core", "core_only", is_flag=True, help="Only show core memory files")
 @click.option("--format", "fmt", type=click.Choice(["text", "json"]))
 def list_cmd(category, core_only, fmt):

--- a/palinode/cli/prompt.py
+++ b/palinode/cli/prompt.py
@@ -4,6 +4,7 @@ from rich.table import Table
 
 from palinode.cli._api import HTTPStatusError, api_client
 from palinode.cli._format import console, get_default_format, OutputFormat, print_result
+from palinode.core.parity import PROMPT_TASKS
 
 
 @click.group()
@@ -13,7 +14,7 @@ def prompt():
 
 
 @prompt.command(name="list")
-@click.option("--task", type=click.Choice(["compaction", "extraction", "update", "classification", "nightly-consolidation"]),
+@click.option("--task", type=click.Choice(PROMPT_TASKS),
               help="Filter by task type")
 @click.option("--format", "fmt", type=click.Choice(["text", "json"]), default=None)
 def prompt_list(task: str | None, fmt: str | None) -> None:

--- a/palinode/cli/save.py
+++ b/palinode/cli/save.py
@@ -3,10 +3,17 @@ import json as _json
 import click
 from palinode.cli._api import api_client
 from palinode.cli._format import console, print_result, get_default_format, OutputFormat
+from palinode.core.parity import MEMORY_TYPES
 
 @click.command()
 @click.argument("content", required=False)
-@click.option("--type", "memory_type", required=False, help="Memory type (e.g. PersonMemory, Decision, Insight, ProjectSnapshot)")
+@click.option(
+    "--type",
+    "memory_type",
+    type=click.Choice(MEMORY_TYPES),
+    required=False,
+    help="Memory type (e.g. PersonMemory, Decision, Insight, ProjectSnapshot)",
+)
 @click.option("--ps", "is_ps", is_flag=True, help="Shorthand for --type ProjectSnapshot (Palinode Save a mid-session snapshot)")
 @click.option("--entity", "entities", multiple=True, help="Entity tag (e.g. person/X, project/X)")
 @click.option(

--- a/palinode/cli/search.py
+++ b/palinode/cli/search.py
@@ -3,6 +3,7 @@ import click
 from palinode.cli._api import api_client
 from palinode.cli._format import print_result, console, OutputFormat, get_default_format
 from palinode.core.config import config
+from palinode.core.parity import CATEGORIES, MEMORY_TYPES
 
 
 def _cli_resolve_context() -> list[str] | None:
@@ -28,7 +29,7 @@ def _cli_resolve_context() -> list[str] | None:
 @click.option("--limit", default=3, help="Number of results (default: 3)")
 @click.option(
     "--category",
-    type=click.Choice(["people", "projects", "decisions", "insights", "research"]),
+    type=click.Choice(CATEGORIES),
     help="Filter by memory directory (people, projects, decisions, insights, research)",
 )
 @click.option(
@@ -44,6 +45,7 @@ def _cli_resolve_context() -> list[str] | None:
 @click.option(
     "--types",
     "types",
+    type=click.Choice(MEMORY_TYPES),
     multiple=True,
     help=(
         "Filter by memory type (PersonMemory, Decision, ProjectSnapshot, Insight, "

--- a/palinode/core/parity.py
+++ b/palinode/core/parity.py
@@ -202,7 +202,7 @@ REGISTRY: tuple[Operation, ...] = (
                 default_key="SEARCH_THRESHOLD_DEFAULT",
             ),
             CanonicalParam(name="since_days", type="integer"),
-            CanonicalParam(name="types", type="array"),
+            CanonicalParam(name="types", type="array", enum=MEMORY_TYPES),
             CanonicalParam(name="min_priority", type="integer"),
             CanonicalParam(name="date_after", type="string"),
             CanonicalParam(name="date_before", type="string"),

--- a/palinode/mcp.py
+++ b/palinode/mcp.py
@@ -49,6 +49,7 @@ from palinode.core.defaults import (
     SESSION_END_TIMEOUT_SECONDS as _SESSION_END_TIMEOUT,
     _SESSION_END_TIMEOUT_SENTINEL as _SENTINEL,
 )
+from palinode.core.parity import CATEGORIES, MEMORY_TYPES, PROMPT_TASKS
 
 logger = logging.getLogger("palinode.mcp")
 logging.basicConfig(level=logging.WARNING)  # quiet — don't pollute stdio
@@ -613,7 +614,7 @@ def _all_tools() -> list[types.Tool]:
                     "category": {
                         "type": "string",
                         "description": "Filter by category: people, projects, decisions, insights, research",
-                        "enum": ["people", "projects", "decisions", "insights", "research"],
+                        "enum": list(CATEGORIES),
                     },
                     "core_only": {
                         "type": "boolean",
@@ -674,7 +675,7 @@ def _all_tools() -> list[types.Tool]:
                     "category": {
                         "type": "string",
                         "description": "Filter by category (memory directory name): people, projects, decisions, insights, research",
-                        "enum": ["people", "projects", "decisions", "insights", "research"],
+                        "enum": list(CATEGORIES),
                     },
                     "limit": {
                         "type": "integer",
@@ -713,14 +714,7 @@ def _all_tools() -> list[types.Tool]:
                         "type": "array",
                         "items": {
                             "type": "string",
-                            "enum": [
-                                "PersonMemory",
-                                "Decision",
-                                "ProjectSnapshot",
-                                "Insight",
-                                "ResearchRef",
-                                "ActionItem",
-                            ],
+                            "enum": list(MEMORY_TYPES),
                         },
                         "description": "Filter by memory type (matches frontmatter `type`).",
                     },
@@ -767,7 +761,7 @@ def _all_tools() -> list[types.Tool]:
                     "type": {
                         "type": "string",
                         "description": "Memory type. Required unless `ps=true` is given.",
-                        "enum": ["PersonMemory", "Decision", "ProjectSnapshot", "Insight", "ResearchRef", "ActionItem"],
+                        "enum": list(MEMORY_TYPES),
                     },
                     "ps": {
                         "type": "boolean",
@@ -1559,7 +1553,7 @@ def _all_tools() -> list[types.Tool]:
                     "task": {
                         "type": "string",
                         "description": "For 'list': filter by task type",
-                        "enum": ["compaction", "extraction", "update", "classification", "nightly-consolidation"],
+                        "enum": list(PROMPT_TASKS),
                     },
                 },
                 "required": ["action"],

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -13,6 +13,31 @@ import * as path from "path";
 import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 
+// Keep these literals aligned with palinode/core/parity.py. The plugin cannot
+// import Python; plugin/test/parity.test.ts enforces exact cross-language drift.
+const PALINODE_CATEGORIES = [
+  "people",
+  "projects",
+  "decisions",
+  "insights",
+  "research",
+] as const;
+const PALINODE_MEMORY_TYPES = [
+  "PersonMemory",
+  "Decision",
+  "ProjectSnapshot",
+  "Insight",
+  "ResearchRef",
+  "ActionItem",
+] as const;
+
+function literalUnion(
+  values: readonly string[],
+  options?: { description?: string },
+) {
+  return Type.Union(values.map((value) => Type.Literal(value)), options);
+}
+
 // ============================================================================
 // Config
 // ============================================================================
@@ -335,9 +360,9 @@ const palinodePlugin = {
         parameters: Type.Object({
           query: Type.String({ description: "Natural language search query" }),
           category: Type.Optional(
-            Type.String({
+            literalUnion(PALINODE_CATEGORIES, {
               description:
-                "Filter by category: person, project, decision, insight, research",
+                `Filter by category: ${PALINODE_CATEGORIES.join(", ")}`,
             }),
           ),
           limit: Type.Optional(
@@ -350,7 +375,9 @@ const palinodePlugin = {
             Type.Number({ description: "Only return memories from the last N days." }),
           ),
           types: Type.Optional(
-            Type.Array(Type.String(), { description: "Filter by memory type (e.g. Decision, Insight)." }),
+            Type.Array(literalUnion(PALINODE_MEMORY_TYPES), {
+              description: "Filter by memory type (e.g. Decision, Insight).",
+            }),
           ),
           date_after: Type.Optional(
             Type.String({ description: "Filter results after an ISO date (e.g. 2024-01-01)." }),
@@ -443,9 +470,9 @@ const palinodePlugin = {
           "Save a memory to Palinode. Use for decisions, insights, person context, or project updates worth remembering across sessions.",
         parameters: Type.Object({
           content: Type.String({ description: "What to remember" }),
-          type: Type.String({
+          type: literalUnion(PALINODE_MEMORY_TYPES, {
             description:
-              "Memory type: PersonMemory, Decision, ProjectSnapshot, Insight, ActionItem",
+              `Memory type: ${PALINODE_MEMORY_TYPES.join(", ")}`,
           }),
           entities: Type.Optional(
             Type.Array(Type.String(), {

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -14,7 +14,7 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 
 // Keep these literals aligned with palinode/core/parity.py. The plugin cannot
-// import Python; plugin/test/parity.test.ts enforces exact cross-language drift.
+// import Python; tests/test_surface_parity.py enforces exact cross-language drift.
 const PALINODE_CATEGORIES = [
   "people",
   "projects",

--- a/plugin/test/parity.test.ts
+++ b/plugin/test/parity.test.ts
@@ -136,6 +136,24 @@ function pluginParamNames(tool: CapturedTool | undefined): Set<string> {
   return new Set(Object.keys(tool.parameters.properties));
 }
 
+function schemaEnum(schema: any): string[] | null {
+  if (!schema || typeof schema !== "object") return null;
+  if (Array.isArray(schema.enum)) return schema.enum.map(String);
+  if (schema.type === "array") return schemaEnum(schema.items);
+
+  const values: string[] = [];
+  for (const branch of schema.anyOf ?? []) {
+    if (branch?.type === "null") continue;
+    if (Object.prototype.hasOwnProperty.call(branch ?? {}, "const")) {
+      values.push(String(branch.const));
+      continue;
+    }
+    const nested = schemaEnum(branch);
+    if (nested) values.push(...nested);
+  }
+  return values.length > 0 ? values : null;
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -247,6 +265,15 @@ describe("ADR-010 plugin canonical params", () => {
           `known_drift[("plugin", "${param.name}")] = <issue> on the ` +
           `Operation in palinode/core/parity.py.`,
       ).toBe(true);
+
+      if (param.enum !== null) {
+        const schema = (tool!.parameters.properties as Record<string, any>)[param.name];
+        expect(
+          schemaEnum(schema),
+          `${op.name}/plugin/${param.name}: enum must exactly match ` +
+            `palinode/core/parity.py`,
+        ).toEqual(param.enum);
+      }
     });
   }
 });

--- a/plugin/test/parity.test.ts
+++ b/plugin/test/parity.test.ts
@@ -136,24 +136,6 @@ function pluginParamNames(tool: CapturedTool | undefined): Set<string> {
   return new Set(Object.keys(tool.parameters.properties));
 }
 
-function schemaEnum(schema: any): string[] | null {
-  if (!schema || typeof schema !== "object") return null;
-  if (Array.isArray(schema.enum)) return schema.enum.map(String);
-  if (schema.type === "array") return schemaEnum(schema.items);
-
-  const values: string[] = [];
-  for (const branch of schema.anyOf ?? []) {
-    if (branch?.type === "null") continue;
-    if (Object.prototype.hasOwnProperty.call(branch ?? {}, "const")) {
-      values.push(String(branch.const));
-      continue;
-    }
-    const nested = schemaEnum(branch);
-    if (nested) values.push(...nested);
-  }
-  return values.length > 0 ? values : null;
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -265,15 +247,6 @@ describe("ADR-010 plugin canonical params", () => {
           `known_drift[("plugin", "${param.name}")] = <issue> on the ` +
           `Operation in palinode/core/parity.py.`,
       ).toBe(true);
-
-      if (param.enum !== null) {
-        const schema = (tool!.parameters.properties as Record<string, any>)[param.name];
-        expect(
-          schemaEnum(schema),
-          `${op.name}/plugin/${param.name}: enum must exactly match ` +
-            `palinode/core/parity.py`,
-        ).toEqual(param.enum);
-      }
     });
   }
 });

--- a/tests/test_auto_summary_async.py
+++ b/tests/test_auto_summary_async.py
@@ -94,7 +94,7 @@ class TestSaveDoesNotCallSummary:
         with _patch_scan(), _patch_embed(), _patch_desc_success():
             res = client.post(
                 "/save",
-                json={"content": big_content, "type": "Note",
+                json={"content": big_content, "type": "Insight",
                       "slug": "not-core", "core": False},
             )
         assert res.status_code == 200, res.text

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -23,7 +23,9 @@ from __future__ import annotations
 import asyncio
 import inspect
 import os
+import re
 import typing
+from pathlib import Path
 from typing import Any
 
 import click
@@ -400,6 +402,32 @@ def test_prompt_task_enum_matches(surface: Surface) -> None:
     assert actual == PROMPT_TASKS, (
         f"prompt/{surface}/task: enum drift; "
         f"expected {PROMPT_TASKS}, found {actual}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("constant_name", "expected"),
+    [
+        ("PALINODE_CATEGORIES", CATEGORIES),
+        ("PALINODE_MEMORY_TYPES", MEMORY_TYPES),
+    ],
+)
+def test_plugin_enum_matches(
+    constant_name: str, expected: tuple[str, ...]
+) -> None:
+    """The plugin's TypeScript literals mirror Python's canonical tuples."""
+    source = (
+        Path(__file__).resolve().parents[1] / "plugin" / "index.ts"
+    ).read_text(encoding="utf-8")
+    match = re.search(
+        rf"const\s+{re.escape(constant_name)}\s*=\s*\[(?P<body>.*?)\]\s*as const;",
+        source,
+        re.DOTALL,
+    )
+    assert match is not None, f"plugin/index.ts is missing {constant_name}"
+    actual = tuple(re.findall(r'"([^"]+)"', match.group("body")))
+    assert actual == expected, (
+        f"plugin/{constant_name}: enum drift; expected {expected}, found {actual}"
     )
 
 

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -32,8 +32,10 @@ from pydantic import BaseModel
 
 from palinode.cli import main as cli_root
 from palinode.core.parity import (
+    CATEGORIES,
     INVENTORY_BACKLOG,
     INVENTORY_INFRA,
+    MEMORY_TYPES,
     REGISTRY,
     CanonicalParam,
     Operation,
@@ -94,6 +96,17 @@ def _cli_param_names(cmd: click.Command) -> set[str]:
     return names
 
 
+def _cli_param_enum(cmd: click.Command, param_name: str) -> tuple[str, ...] | None:
+    """Return a Click option's choices, normalized to the canonical name."""
+    aliases = {"type": "memory_type"}
+    click_name = aliases.get(param_name, param_name)
+    for param in cmd.params:
+        if param.name != click_name or not isinstance(param.type, click.Choice):
+            continue
+        return tuple(str(choice) for choice in param.type.choices)
+    return None
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # MCP extraction
 # ─────────────────────────────────────────────────────────────────────────────
@@ -131,6 +144,32 @@ def _mcp_param_names(tool_name: str) -> set[str]:
         return set()
     props = schema.get("properties", {}) or {}
     return set(props.keys())
+
+
+def _schema_enum(schema: dict[str, Any]) -> tuple[str, ...] | None:
+    """Extract an exact string enum from scalar or array JSON Schema."""
+    if "enum" in schema:
+        return tuple(str(value) for value in schema["enum"])
+    if schema.get("type") == "array":
+        return _schema_enum(schema.get("items", {}) or {})
+
+    values: list[str] = []
+    for branch in schema.get("anyOf", []) or []:
+        if branch.get("type") == "null":
+            continue
+        if "const" in branch:
+            values.append(str(branch["const"]))
+            continue
+        nested = _schema_enum(branch)
+        if nested is not None:
+            values.extend(nested)
+    return tuple(values) if values else None
+
+
+def _mcp_param_enum(tool_name: str, param_name: str) -> tuple[str, ...] | None:
+    schema = _mcp_tools().get(tool_name, {})
+    prop = (schema.get("properties", {}) or {}).get(param_name, {})
+    return _schema_enum(prop)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -185,6 +224,38 @@ def _api_param_names(method: str, path: str) -> set[str]:
     return set()
 
 
+def _resolve_openapi_schema(
+    document: dict[str, Any], schema: dict[str, Any]
+) -> dict[str, Any]:
+    """Resolve the local component refs FastAPI emits for request models."""
+    ref = schema.get("$ref")
+    if not ref:
+        return schema
+    node: Any = document
+    for part in ref.removeprefix("#/").split("/"):
+        if not part:
+            continue
+        node = node[part]
+    return node
+
+
+def _api_param_enum(method: str, path: str, param_name: str) -> tuple[str, ...] | None:
+    """Read a query/body parameter enum from the generated OpenAPI schema."""
+    from palinode.api.server import app  # lazy
+
+    document = app.openapi()
+    operation = document["paths"][path][method.lower()]
+    for parameter in operation.get("parameters", []) or []:
+        if parameter.get("name") == param_name:
+            return _schema_enum(parameter.get("schema", {}) or {})
+
+    body = operation.get("requestBody", {}).get("content", {})
+    schema = body.get("application/json", {}).get("schema", {})
+    schema = _resolve_openapi_schema(document, schema)
+    prop = (schema.get("properties", {}) or {}).get(param_name, {})
+    return _schema_enum(prop)
+
+
 def _is_request_helper(annotation: Any) -> bool:
     """Best-effort check for FastAPI ``Request``/``Response`` helpers."""
     try:
@@ -220,6 +291,31 @@ def _surface_param_names(op: Operation, surface: Surface) -> set[str]:
     if surface == "plugin":
         # Plugin parity is documented in PARITY.md, not asserted in v0.
         return set()
+    raise AssertionError(f"unknown surface {surface!r}")
+
+
+def _surface_param_enum(
+    op: Operation, surface: Surface, param_name: str
+) -> tuple[str, ...] | None:
+    if surface == "cli":
+        if op.cli_command is None:
+            return None
+        cmd = _resolve_cli_command(op.cli_command)
+        return _cli_param_enum(cmd, param_name) if cmd is not None else None
+    if surface == "mcp":
+        return (
+            _mcp_param_enum(op.mcp_tool, param_name)
+            if op.mcp_tool is not None
+            else None
+        )
+    if surface == "api":
+        return (
+            _api_param_enum(*op.api_endpoint, param_name)
+            if op.api_endpoint is not None
+            else None
+        )
+    if surface == "plugin":
+        return None
     raise AssertionError(f"unknown surface {surface!r}")
 
 
@@ -266,6 +362,44 @@ def test_canonical_param_present(case: tuple[Operation, Surface, CanonicalParam]
         f"(found: {sorted(surface_params)}). "
         f"If this is intentional drift, add `known_drift[(\"{surface}\", "
         f"\"{cp.name}\")] = <issue>` on the Operation."
+    )
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        case
+        for case in _flatten_cases()
+        if case[2].enum in (CATEGORIES, MEMORY_TYPES)
+    ],
+    ids=_case_id,
+)
+def test_canonical_enum_matches(case: tuple[Operation, Surface, CanonicalParam]) -> None:
+    """Every category/type enum exposes the exact canonical values."""
+    op, surface, cp = case
+    expected = tuple(cp.enum or ())
+    actual = _surface_param_enum(op, surface, cp.name)
+    assert actual == expected, (
+        f"{op.name}/{surface}/{cp.name}: enum drift; "
+        f"expected {expected}, found {actual}"
+    )
+
+
+@pytest.mark.parametrize("surface", ["cli", "mcp", "api"])
+def test_prompt_task_enum_matches(surface: Surface) -> None:
+    """Prompt tasks stay aligned even while prompt remains registry backlog."""
+    from palinode.core.parity import PROMPT_TASKS
+
+    if surface == "cli":
+        cmd = _resolve_cli_command("prompt list")
+        actual = _cli_param_enum(cmd, "task") if cmd is not None else None
+    elif surface == "mcp":
+        actual = _mcp_param_enum("palinode_prompt", "task")
+    else:
+        actual = _api_param_enum("GET", "/prompts", "task")
+    assert actual == PROMPT_TASKS, (
+        f"prompt/{surface}/task: enum drift; "
+        f"expected {PROMPT_TASKS}, found {actual}"
     )
 
 


### PR DESCRIPTION
Closes #69.

## Why

`CATEGORIES`, `MEMORY_TYPES`, and `PROMPT_TASKS` were documented as the canonical cross-surface contract, but each Python surface repeated literals and the TypeScript plugin had already drifted. That left plural categories, `ResearchRef`, and `nightly-consolidation` inconsistent depending on which surface a caller used.

## What changed

- import the canonical tuples in CLI, MCP, and REST schemas
- make REST and CLI category/type choices closed enums, including search type filters
- mirror the canonical category and memory-type literals in the OpenClaw plugin, with an explicit pointer back to `core/parity.py`
- extend the Python parity suite to compare real Click, MCP, and OpenAPI schema values and read the plugin constants using the repository’s established cross-language guard pattern
- update the parity docs, changelog, and one test fixture that used the now-invalid `Note` type

## Behavior note

I checked the API paths for singular categories. They were not accepted as aliases or coerced to plural values: list compared the raw value to the directory name, search forwarded the raw value to storage, and the plugin forwarded its free-form string unchanged. A singular category could therefore be accepted syntactically but produce no matches. This PR makes that failure explicit by rejecting non-canonical category values. Likewise, unknown save types previously fell back to `inbox`; the closed canonical `MEMORY_TYPES` contract now rejects them instead.

## Verification

- `pytest tests/test_surface_parity.py -q` — 208 passed, 1 expected xfail
- focused real-server/stdio tests — 5 passed
- `npm test` — 61 passed
- strict TypeScript check for `plugin/index.ts` — passed
- `ruff check palinode/ tests/ scripts/` — passed
- `bandit -r palinode/ -ll` — passed

No new dependencies.