### PR TITLE
ci: test the unit suite on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@
 #
 # This replaces the previous ci.yml / main-ci.yml / test.yml trio, whose
 # private-runner jobs could never run here and left every run queued until it
-# expired. All jobs below run on GitHub-hosted ubuntu-latest.
+# expired. All jobs below run on GitHub-hosted runners; unit tests cover Linux
+# plus one macOS lane for filesystem and platform compatibility.
 #
 # All embeddings / LLM calls are mocked in the unit suite — no external
 # services are needed.
@@ -18,11 +19,17 @@ on:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.11"
+          - os: ubuntu-latest
+            python-version: "3.12"
+          - os: macos-latest
+            python-version: "3.12"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }} (Linux)
+        if: runner.os == 'Linux'
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
+
+      - name: Set up Python 3.12 (macOS — extension-loading build)
+        if: runner.os == 'macOS'
+        run: |
+          brew install python@3.12
+          echo "$(brew --prefix python@3.12)/libexec/bin" >> "$GITHUB_PATH"
+
+      - name: Verify loadable SQLite extensions (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          python -c 'import sqlite3; assert hasattr(sqlite3.connect(":memory:"), "enable_load_extension")'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,8 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install python@3.12
-          echo "$(brew --prefix python@3.12)/libexec/bin" >> "$GITHUB_PATH"
+          "$(brew --prefix python@3.12)/bin/python3.12" -m venv "$RUNNER_TEMP/palinode-venv"
+          echo "$RUNNER_TEMP/palinode-venv/bin" >> "$GITHUB_PATH"
 
       - name: Verify loadable SQLite extensions (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
Closes #70.

## Why

Palinode advertises OS-independent support and relies on filesystem behavior that differs on macOS, but the unit suite only ran on Ubuntu. That left macOS path resolution, encoding, and security-sensitive file handling outside the pre-merge signal.

## What changed

- retain the existing Ubuntu Python 3.11 and 3.12 unit-test lanes
- add a macOS-latest unit-test lane on Python 3.12
- drive the unit-test job from an explicit OS/Python include matrix
- update the workflow header so it no longer claims every job runs on Ubuntu

## Verification

- parsed the workflow YAML and verified all three matrix entries
- ran the same non-integration unit-test scope locally on Darwin: 2539 passed, 9 skipped, 5 xfailed
- git diff --check passed

CI-only change: skip-changelog.
