### PR TITLE
test: cover all quote punctuation folds

### DIFF
--- a/tests/test_quote_verify.py
+++ b/tests/test_quote_verify.py
@@ -10,6 +10,7 @@ Real tmp files only — no mocks (repo rule). The primitive is network-free.
 """
 from __future__ import annotations
 
+import pytest
 
 from palinode.core.quote_verify import (
     QuoteStatus,
@@ -25,6 +26,33 @@ def test_normalize_is_idempotent_and_folds_punctuation():
     once = normalize_quote(raw)
     assert once == '"Curly" quotes-and spaces'
     assert normalize_quote(once) == once  # idempotent
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("\u2018", "'"),
+        ("\u2019", "'"),
+        ("\u201a", "'"),
+        ("\u201b", "'"),
+        ("\u201c", '"'),
+        ("\u201d", '"'),
+        ("\u201e", '"'),
+        ("\u201f", '"'),
+        ("\u2013", "-"),
+        ("\u2014", "-"),
+        ("\u2212", "-"),
+        ("x\u00a0y", "x y"),
+        ("x\u2009y", "x y"),
+        ("x\u202fy", "x y"),
+        ("x\u200by", "xy"),
+        ("\u2026", "..."),
+    ],
+)
+def test_normalize_folds_each_punctuation_entry(source, expected):
+    normalized = normalize_quote(source)
+    assert normalized == expected
+    assert normalize_quote(normalized) == normalized
 
 
 def test_quote_hash_stable_across_cosmetic_variation():


### PR DESCRIPTION
## Why

`normalize_quote` relies on a fixed punctuation map for stable source-anchor hashes. Explicit vectors make every mapping entry, including invisible spacing characters, independently reviewable and protect the normalization contract from accidental drift.

## What changed

- add parametrized vectors for every smart quote, dash, spacing, zero-width-space, and ellipsis mapping
- verify normalization remains idempotent for every expected output
- leave production code unchanged

Closes #68

## Validation

- `pytest tests/test_quote_verify.py -q` (26 passed)
- `ruff check palinode tests scripts`
- `bandit -r palinode -ll -q`
- related suite: 84 passed; 5 existing Windows-only failures from directory `fsync` and path-separator assumptions in `test_source_capture_g1.py`

This is a test-only change, so no changelog entry is included.