### PR TITLE
Gate palinode_save inputSchema size directly

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- **`palinode_save` MCP schema size regression now gates compact `inputSchema` (#72).** v0.9.7 trimmed description prose and added a per-tool wire-size budget (#765), but that gate measured name + description + inputSchema together. The new `test_palinode_save_input_schema_fits_budget` enforces a ~3.5 KB (3,584 B) limit on the compact serialized `inputSchema` itself — the form clients cap — so schema growth is caught before a client silently replaces the contract with `{}`.
+
 ### Removed
 
 ### Security

--- a/tests/test_mcp_schema_size_budget.py
+++ b/tests/test_mcp_schema_size_budget.py
@@ -17,12 +17,11 @@ an aggregator's own tool accounting can observe it. Staying under a plausible
 client cap is therefore the only lever available here, and this test is the
 only thing that can notice when a new field spends the remaining room.
 
-**When this test fails, split the tool — do not compress prose.** Shrinking
-descriptions buys a few hundred bytes and leaves the next field to re-break it;
-moving a cohesive parameter cluster to its own tool fixes the class. The
-provenance cluster on ``palinode_save`` (``claims``/``sources``/``backed_by``/
-``contradicts``) is the standing candidate: ~1.4 KB for structures a typical
-save never sends.
+``palinode_save`` is the largest schema and the primary regression target.
+Its ``inputSchema`` is gated at :data:`SAVE_INPUT_SCHEMA_BUDGET_BYTES` (~3.5 KB)
+to leave headroom below the observed 4,096-byte client cap as the contract
+evolves.  Other tools are checked against the full wire size
+(name + description + inputSchema) at :data:`SCHEMA_BUDGET_BYTES`.
 """
 from __future__ import annotations
 
@@ -37,6 +36,16 @@ from palinode.mcp import _all_tools
 #: because the failure mode when a client enforces one is a write tool with no
 #: contract, reported nowhere.
 SCHEMA_BUDGET_BYTES = 4096
+
+#: ``palinode_save`` inputSchema budget (~3.5 KB).  Measured as compact JSON
+#: (``separators=(',', ':')``) — the form clients receive — not the full tool
+#: definition.  Headroom below the 4,096-byte client cap is the deliverable.
+SAVE_INPUT_SCHEMA_BUDGET_BYTES = 3584
+
+
+def _compact_input_schema_size(tool) -> int:
+    """Bytes of one tool's inputSchema, serialized compactly."""
+    return len(json.dumps(tool.input_schema, separators=(",", ":")))
 
 
 def _wire_size(tool) -> int:
@@ -53,6 +62,26 @@ def _wire_size(tool) -> int:
          "inputSchema": tool.input_schema},
         separators=(",", ":"),
     ))
+
+
+def _save_tool():
+    for tool in _all_tools():
+        if tool.name == "palinode_save":
+            return tool
+    raise AssertionError("palinode_save not found in _all_tools()")
+
+
+def test_palinode_save_input_schema_fits_budget():
+    """Regression gate: compact serialized inputSchema, not the full tool def."""
+    tool = _save_tool()
+    size = _compact_input_schema_size(tool)
+    assert size <= SAVE_INPUT_SCHEMA_BUDGET_BYTES, (
+        f"palinode_save inputSchema serializes to {size} B, over the "
+        f"{SAVE_INPUT_SCHEMA_BUDGET_BYTES} B budget by "
+        f"{size - SAVE_INPUT_SCHEMA_BUDGET_BYTES} B. Clients may drop the "
+        f"schema entirely. Trim description prose or split a parameter cluster "
+        f"onto its own tool — see the module docstring."
+    )
 
 
 @pytest.mark.parametrize("tool", _all_tools(), ids=lambda t: t.name)


### PR DESCRIPTION
## Summary

Fixes #72.

Adds a regression gate for the compact serialized `palinode_save` `inputSchema`, matching the schema size that affected MCP clients actually enforce.

Current `main` already contains the description reductions needed to bring the schema to approximately the requested 3.5 KB target, so this PR deliberately avoids further compressing model-facing guidance.

## Size

- Compact `inputSchema`: **3,498 bytes**
- Regression budget: **3,584 bytes**
- Headroom below 4,096-byte client cap: **598 bytes**
- Full tool definition, supplementary: **3,815 bytes**

The regression measurement uses compact JSON serialization of `inputSchema` itself rather than the complete MCP tool definition.

## Changes

- Add a dedicated compact-`inputSchema` size regression test for `palinode_save`
- Keep the existing full-wire-size checks for the other MCP tools
- Document the regression protection in the changelog

No MCP field names, types, requiredness, defaults, validation behavior, or tool semantics change.

## Validation

- `pytest tests/test_mcp_schema_size_budget.py tests/test_mcp_schema_size.py tests/test_mcp_parity.py tests/test_mcp.py -v --tb=short` — **69 passed**
- `pytest tests/ -v --tb=short --ignore=tests/integration` — **2575 passed, 9 skipped, 5 xfailed**
- `ruff check palinode/ tests/ scripts/` — **passed**
- `bandit -r palinode/ -ll` — **passed**
- `git diff --check` — **passed**

Integration tests were not run because they require live integration setup; this change affects only schema-size regression coverage.