### PR TITLE
docs: publish ADR wave 1

### DIFF
--- a/ADR-001-tools-over-pipeline.md
+++ b/ADR-001-tools-over-pipeline.md
@@ -1,0 +1,82 @@
+# ADR-001: Tools Over Pipeline
+
+**Status:** Accepted
+**Date:** 2026-04-01
+**Context:** Claude Mythos announcement, Nate B Jones "compensating complexity" framework
+
+## Decision
+
+Palinode's primary value is its **MCP tool surface + file-based storage + git versioning**, not its 4-phase injection pipeline. The pipeline is scaffolding for current models. The tools survive any model upgrade.
+
+## Context
+
+Nate B Jones' framework distinguishes:
+- **Outcome specs** — what you want (survives model upgrades)
+- **Procedures** — how to do it (breaks on model upgrades)
+- **Tools** — capabilities the model can use (survives)
+- **Compensating complexity** — workarounds for model limitations (disposable)
+
+Applied to Palinode:
+
+### What survives any model
+
+The tool surface as it stood when this was written — illustrative, not a census.
+It has roughly doubled since; the README's tool reference is the current list.
+
+- `palinode_search` — find relevant memories
+- `palinode_save` — store typed memories
+- `palinode_session_end` — capture session outcomes
+- `palinode_list/read` — browse the memory directory
+- `palinode_diff/blame/rollback/push` — git operations
+- `palinode_history` — file-level provenance
+- `palinode_trigger` — prospective recall
+- `palinode_entities` — entity graph
+- `palinode_consolidate` — trigger compaction
+- `palinode_lint` — structural health checks
+- `palinode_ingest` — capture from URLs
+- `palinode_status` — system health
+- Deterministic executor (validates LLM output, applies ops)
+- Markdown files as source of truth
+- Git versioning
+- Security scanning (business rule)
+
+### What's compensating complexity (today's scaffolding)
+- 4-phase auto-injection (Phase 1-4) — compensates for models that don't know to search
+- Trivial message skip list — compensates for models that can't judge query relevance
+- Layer split keyword heuristics — compensates for models that can't classify by content
+- `json_repair` — compensates for models that output malformed JSON
+- Explicit JSON format instructions in compaction prompt — same
+
+## Consequences
+
+### Positioning
+Lead with: "tools + a memory directory your agent uses however it wants."
+Not: "4-phase injection pipeline."
+
+The pipeline is an implementation detail. The tools are the interface.
+
+### Architecture evolution
+1. **v0.5 (at time of writing):** Pipeline + tools. Pipeline does automatic injection. Tools available for explicit use.
+2. **v1.0:** Pipeline becomes optional/configurable. Default to tools-first for capable models. Pipeline as fallback.
+3. **v2.0:** Tools-only mode. Model decides what to retrieve, when to consolidate. Pipeline removed or opt-in legacy.
+
+**Scorecard (added 2026-08).** Step 2 arrived early, at v0.10.0 rather than v1.0:
+injection is gated by `auto_inject.enabled` and suppressed per-harness via
+`auto_inject.harnesses_disabled`, which defaults to disabling it for the harness
+whose own instruction and hook layers already cover session start. Capable clients
+are pointed at the tools instead. That is this ADR's central prediction landing —
+the pipeline became configurable scaffolding while the tool surface grew.
+
+### What stays regardless of version
+- MCP tool interface (the API contract)
+- File-based storage (markdown + git)
+- Deterministic executor (LLM proposes, executor disposes)
+- Security guardrails
+- `core: true` flagging (user intent, not model workaround)
+
+### What to audit on each model upgrade
+Run the compaction pipeline with prompt sections deleted. Measure what gets worse vs what stays the same. Remove what the new model makes unnecessary.
+
+## References
+- Nate B Jones, "Every workaround you built for the last model is now breaking the next one" (April 2026) — the outcome-spec / procedure / tool / compensating-complexity framework this ADR applies
+- As of April 2026, the planner–worker–judge split had converged independently across several frontier coding agents; the structural pattern, not any one vendor's implementation, is what this ADR treats as evidence

--- a/ADR-018-epistemic-markers.md
+++ b/ADR-018-epistemic-markers.md
@@ -1,0 +1,174 @@
+# ADR-018: Epistemic Markers in Memory Files
+
+**Status:** Accepted
+**Date:** 2026-06-28
+**Amended:** 2026-07-18 — `unverified` added as a 4th settable value (#589; originally deferred, see §4)
+**Relates to:** ADR-010 (cross-surface parity contract), ADR-015 (write-semantics axis — the model this follows)
+**Tracks:** #72 (this ADR is its spec); foundation for #533 (typed contradiction + evidence-backing links) and #366 (advisory project-memory review)
+**Milestone:** v0.9.0 (Memory quality + HTTP transport)
+
+---
+
+## 1. Problem
+
+A Palinode memory declares *what topic* it is about (`entities`), *what kind of
+record* it is (`type`: Decision / Insight / …), and *its lifecycle* (`status`,
+`update_policy`). It does **not** declare *how much epistemic weight the claim
+carries*. A directly-observed fact, a model's extrapolation, and an explicitly
+unresolved question are stored identically and recalled identically.
+
+For an audit-grade memory system this is a gap. Three things suffer:
+
+1. **Recall trust.** A reader (human or agent) cannot tell at a glance whether a
+   recalled statement is something that was verified or something the system
+   inferred. Inferences silently acquire the authority of facts.
+2. **Open questions decay invisibly.** "We still don't know whether X" is worth
+   recording, but today it is recorded as if it were a settled fact and is never
+   resurfaced for resolution.
+3. **No anchor for provenance-quality work.** #533's typed contradiction /
+   evidence-backing links and #366's advisory review both want to reason over
+   *kinds* of claims (an `inference` should carry a `backed_by`; a stale
+   `open_question` wants attention). They need a marker to compose over.
+
+## 2. Decision
+
+**Add an optional per-memory frontmatter field `epistemic`** declaring the kind
+of claim the memory makes, orthogonal to `type` and `status`:
+
+```yaml
+epistemic: fact | inference | open_question | unverified
+```
+
+The four **settable** values (what the save surfaces accept and validate):
+
+- **`fact`** — directly observed / verified (an explicit, *earned* claim).
+- **`inference`** — derived or extrapolated from other facts (lower trust;
+  should ideally carry a `backed_by`, shipped in #533).
+- **`open_question`** — unresolved; an explicit marker that this is *not yet*
+  settled.
+- **`unverified`** — asserted but not checked (#589, added 2026-07-18): a
+  positive claim was made, but it was neither verified into `fact` nor derived
+  as an `inference`, and it is not a question. Distinct from `unmarked` — a
+  claim *was* made, honestly labelled as untested. The prime candidate to
+  acquire a `backed_by` link (#533, shipped) and graduate toward `fact`.
+
+**Absence is its own state — `unmarked` — and is NOT equated with `fact`.** A
+memory with no `epistemic` field made no epistemic claim. For an audit-grade
+store this distinction is the whole point: "nobody declared this" must not
+silently inherit the authority of "verified" — defaulting the unmarked majority
+to the *highest*-trust category would be exactly backwards. `unmarked` is
+**trust-neutral**: neither flagged as a problem (no lint noise) nor asserted as
+verified (downstream consumers — #533 backing, #366 review — treat it as "no
+claim", not as fact). It is **not a settable value** (reached only by omitting
+the field, so it is intentionally absent from `VALID_EPISTEMICS`; the surface
+rejects an explicit `unmarked`). Every memory written before this field existed
+is `unmarked` and byte-for-byte unaffected. To assert fact-hood a writer sets
+`epistemic: fact` explicitly. The field is **persisted only when a marker is in
+effect**, so unmarked memories keep clean frontmatter.
+
+(This reverses the initial draft's `DEFAULT_EPISTEMIC = "fact"`. The seam that
+forced the change: treating unmarked as fact conflates two different questions —
+*was a claim made?* (field presence) and *what kind?* (the value) — and grants
+false authority to the un-vetted majority. The provenance panel already rendered
+"fact (default)" distinctly from an explicit fact; making the default `unmarked`
+makes that honesty load-bearing instead of cosmetic.)
+
+**Sticky.** Like `update_policy` and `created_at` (ADR-015 §2.1/§2.4), the marker
+carries forward across a re-save of the same `(category, slug)` that omits it —
+re-saving is "the same logical memory," so the claim's epistemic state should
+survive a save that forgets to restate it. The integrity argument is decisive:
+non-sticky would let a re-save **silently drop** a deliberate `fact`,
+`inference`, or `open_question` back to `unmarked` — erasing a claim the writer
+deliberately made. To *change* a marker the
+writer states the new value explicitly (e.g. `epistemic=fact` resolves an open
+question into a verified fact); only silent omission inherits. A memory that was
+never marked still writes no frontmatter and reads as `unmarked`, so the
+stickiness only ever preserves an intent the writer already expressed.
+Resolution order: explicit param > `metadata` value > inherited prior marker >
+unset (`unmarked`, unwritten).
+
+Note that stickiness is a **write-path implementation choice, not a property of
+the marker vocabulary**. It follows from how this system handles re-saves of the
+same logical memory (ADR-015); a different store could adopt the same four values
+with different write semantics and lose nothing. The vocabulary and the
+absent-is-not-fact rule are the portable parts.
+
+**On naming the absent state.** `unmarked` is this implementation's name for
+"no epistemic field was set." It is not a fifth value: the save surfaces reject
+it, and it is deliberately absent from `VALID_EPISTEMICS`. Read-side projections
+(trace output, the provenance panel) may render the word so that absence is
+*visible* rather than blank — but what they are naming is the absence itself.
+Anything consuming this field should test for the field's presence, not compare
+against the string.
+
+### Where it lives
+
+- **Vocabulary source of truth:** `VALID_EPISTEMICS` + `DEFAULT_EPISTEMIC` in
+  `palinode/core/parser.py` (alongside `VALID_STATUSES` / `VALID_UPDATE_POLICIES`).
+- **Validated at the save surface** (`/save`): an unknown value is rejected with
+  HTTP 400 rather than silently coerced — a typo'd `inferrence` must not land in
+  frontmatter. The value is resolved from the first-class param *or* the
+  free-form `metadata` dict (the explicit param wins) and validated once, so a
+  metadata-supplied value can't slip past unvalidated.
+- **Settable on save across all four interfaces (ADR-010 parity):** MCP
+  (`palinode_save` enum param), REST (`SaveRequest.epistemic`), CLI
+  (`palinode save --epistemic`), plugin (`palinode_save` union literal).
+- **Surfaced on recall:** asserted markers (`inference`, `open_question`) are
+  labelled in MCP search results (`fact` and `unmarked` stay unlabelled to avoid
+  noise); the `/ui` provenance panel renders a **Claim type** row — `unmarked`
+  shown trust-neutral, `fact` as an asserted claim, `open_question` in warn
+  styling.
+- **Lint:** `palinode lint` reports `stale_open_questions` — an
+  `epistemic: open_question` older than the stale threshold (90 days) wants
+  resolution. Independent of `status` (epistemic state, not lifecycle).
+
+## 3. Consequences
+
+- **Additive and safe.** Optional field, default `unmarked`, written only when a
+  marker is set; no migration and no schema-version bump required — `epistemic`
+  is simply another optional field under the current implicit schema.
+- **Foundation, not the whole story.** `epistemic` says *what kind* of claim a
+  memory is; it does not say *what supports it* or *what it conflicts with* —
+  that is #533's `backed_by` / `contradicts`, since shipped. An `inference` was
+  honestly marked as lower-trust even before #533 gave it a backing link.
+- **Composable.** #366's advisory review consumes `open_question` markers (and
+  #533's `contradicts` links) as quality signals over the whole project's memory.
+- **No portability claim is made here.** These four values are a vocabulary this
+  store validates; nothing in this ADR asserts that another system's `inference`
+  means the same thing. A memory file carries no declaration that it was written
+  under any shared convention, so a reader cannot yet distinguish a deliberately
+  marked record from one that merely looks similar. Closing that gap needs a
+  published specification to point at, which is deliberately not this document's
+  job.
+- **Consolidation is unchanged.** The deterministic executor does not infer or
+  rewrite `epistemic`; it is a writer assertion. (A future enhancement could let
+  consolidation *propose* promoting a resolved `open_question`, but proposing —
+  never silently applying — stays the discipline.)
+
+## 4. Alternatives considered
+
+- **A new `type` value (e.g. `OpenQuestion`).** Rejected: `type` selects the
+  storage directory and the record's shape; epistemic weight is orthogonal to
+  both. An Insight, a Decision, and a ProjectSnapshot can each be a fact, an
+  inference, or an open question. Overloading `type` would multiply the type
+  vocabulary combinatorially.
+- **Reuse `confidence` (0.0–1.0).** Rejected: a continuous confidence score and
+  a discrete claim-kind answer different questions. "This is an open question" is
+  not "confidence 0.3"; an unresolved question has no meaningful point estimate.
+  The two can coexist (an `inference` may also carry a `confidence`).
+- **Free-form tag in `metadata`.** Rejected: no validation, no parity guarantee,
+  no canonical vocabulary — exactly the drift ADR-010 exists to prevent.
+- **Only three settable values (defer `unverified`).** The original decision
+  shipped `fact`/`inference`/`open_question` and deferred a 4th
+  "asserted-but-not-checked" value to keep the initial change scoped; such
+  claims fell through to `unmarked`, conflating "claim made but untested" with
+  "no claim made at all". Superseded 2026-07-18 by #589: `unverified` is now
+  the 4th settable value (see §2).
+
+  This is worth stating plainly rather than burying in an amendment note: the
+  fourth value was **not** designed in. Three values shipped, ran against a real
+  corpus, and the gap surfaced as a category of claim that kept landing in the
+  wrong bucket. Any closed vocabulary is a bet; this one has at least been
+  tested against practice and revised once for a stated reason. That is the
+  strongest argument available for holding it closed now — and the reason to
+  keep it revisable if a fifth gap surfaces the same way.

--- a/claude-plugin/README.md
+++ b/claude-plugin/README.md
@@ -115,7 +115,7 @@ Once installed and connected, the plugin exposes 28 MCP tools to Claude Code:
 - `palinode_entities` — entity graph traversal (people, projects, decisions)
 
 ### Save and capture
-- `palinode_save` — write a new memory item. Supports type, entities, core flag, slug, source. As of v0.6.0, saves run write-time contradiction checking in the background (ADR-004).
+- `palinode_save` — write a new memory item. Supports type, entities, core flag, slug, source. Saves can also run a background write-time contradiction check against similar existing memories — opt-in, off by default: set `consolidation.write_time.enabled: true` in your config. The check never blocks or fails the save.
 - `palinode_session_end` — capture session outcomes (summary, decisions, blockers) to daily notes and project status files
 - `palinode_ingest` — fetch a URL and store it as a research reference
 
@@ -170,6 +170,7 @@ Run `palinode_status` and check `total_files` and `fts_chunks`. If both are 0, t
 - [Main repository](https://github.com/phasespace-labs/palinode)
 - [CHANGELOG](https://github.com/phasespace-labs/palinode/blob/main/docs/CHANGELOG.md) for the latest release notes
 - [Compaction demo](https://github.com/phasespace-labs/palinode/tree/main/examples/compaction-demo) — walkthrough of a memory file across three consolidation passes with blame + diff output
+- [ADR-001: Tools Over Pipeline](https://github.com/phasespace-labs/palinode/blob/main/ADR-001-tools-over-pipeline.md) — why the executor is deterministic
 
 ## License
 

--- a/examples/compaction-demo/README.md
+++ b/examples/compaction-demo/README.md
@@ -41,7 +41,7 @@ Between pass 1 and pass 2 (9 operations):
 - 4 × `ARCHIVE` — moved superseded entries to `archive/2026/my-app-status.md`
 - 2 × `UPDATE` — final wording pass on merged lines
 
-All 22 operations arrived as structured JSON like `{"op": "SUPERSEDE", "id": "f-0317-1", "superseded_by": "f-0324-2", "reason": "stripe integration actually shipped on the 24th"}`. Palinode validates each operation and applies it through `palinode/consolidation/executor.py`, preserving a reviewable commit trail.
+All 22 operations were **proposed by an LLM** but **applied by deterministic Python** (`palinode/consolidation/executor.py`). The LLM never touches the file directly — it only emits JSON like `{"op": "SUPERSEDE", "id": "f-0317-1", "superseded_by": "f-0324-2", "reason": "stripe integration actually shipped on the 24th"}` and the executor validates and applies it. That's the [ADR-001](../../ADR-001-tools-over-pipeline.md) invariant in action.
 
 ## Why this matters
 


### PR DESCRIPTION
## Summary

- publish ADR-001 (Tools Over Pipeline) and ADR-018 (Epistemic Markers)
- add the corresponding documentation links
- correct the Claude plugin save docs: write-time contradiction checks are opt-in and never block the save

## Validation

- shipping-path and shipping-content checks
- 2,721 Python tests (11 skipped, 5 expected xfails)
- Ruff and Bandit
- 61 plugin tests
- package build and Twine checks
- isolated wheel install verified `palinode 0.10.1` with `mcp 2.0.0`