### PR TITLE
test: isolate doctor filesystem discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,7 @@ addopts = "--ignore=tests/live"
 pythonpath = ["."]
 markers = [
     "slow: marks tests that need Ollama or take >5s",
+    "doctor_real_search_roots: allow a test to exercise doctor's built-in filesystem root discovery",
 ]
 asyncio_mode = "strict"
 timeout = 60

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,33 @@ def _isolate_global_config():
 
 
 @pytest.fixture(autouse=True)
+def _isolate_doctor_search_roots(
+    request: pytest.FixtureRequest,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    _isolate_global_config,
+) -> None:
+    """Keep doctor filesystem discovery inside each test's temp directory.
+
+    An empty ``config.doctor.search_roots`` enables the production fallback,
+    which includes the user's entire home directory. Tests that invoke doctor
+    through the process-wide config must never inherit that machine-dependent
+    behavior: it is slow, can discover a developer's real databases, and makes
+    wall-clock results depend on the size of ``$HOME``.
+
+    A test that specifically covers the production fallback may opt out with
+    ``@pytest.mark.doctor_real_search_roots``. Keep that marker narrow: ordinary
+    doctor behavior tests should provide explicit roots instead.
+    """
+    if request.node.get_closest_marker("doctor_real_search_roots") is not None:
+        return
+
+    from palinode.core.config import config
+
+    monkeypatch.setattr(config.doctor, "search_roots", [str(tmp_path)])
+
+
+@pytest.fixture(autouse=True)
 def _warm_embed_gate(monkeypatch):
     from palinode.indexer import reconcile as reconcile_mod
 

--- a/tests/test_diagnostics_skeleton.py
+++ b/tests/test_diagnostics_skeleton.py
@@ -33,6 +33,9 @@ def _ctx(memory_dir: Path) -> DoctorContext:
         memory_dir=str(memory_dir),
         db_path=str(memory_dir / ".palinode.db"),
     )
+    # This synthetic config intentionally bypasses the process-wide singleton
+    # isolated by tests/conftest.py, so pin its doctor walk explicitly too.
+    cfg.doctor.search_roots = [str(memory_dir)]
     return DoctorContext(config=cfg)
 
 

--- a/tests/test_doctor_test_isolation.py
+++ b/tests/test_doctor_test_isolation.py
@@ -1,0 +1,36 @@
+"""Regression coverage for doctor filesystem isolation in the test suite."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from palinode.core.config import config
+from palinode.diagnostics.checks import phantom_db
+from palinode.diagnostics.types import DoctorContext
+
+
+def test_default_doctor_walk_stays_inside_tmp_path(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """The suite default must not let doctor walk a developer's real home."""
+    visited_roots: list[Path] = []
+    real_walk = os.walk
+
+    def recording_walk(root, *args, **kwargs):
+        visited_roots.append(Path(root).resolve())
+        yield from real_walk(root, *args, **kwargs)
+
+    monkeypatch.setattr(phantom_db.os, "walk", recording_walk)
+
+    phantom_db.phantom_db_files(DoctorContext(config=config))
+
+    assert visited_roots == [tmp_path.resolve()]
+
+
+@pytest.mark.doctor_real_search_roots
+def test_real_search_roots_marker_opts_out(tmp_path: Path) -> None:
+    """The explicit marker leaves production root discovery unmodified."""
+    assert str(tmp_path) not in config.doctor.search_roots


### PR DESCRIPTION
Closes #86

## Why

An empty `config.doctor.search_roots` activates the production fallback, which includes the user's entire home directory. Tests that invoke doctor through the process-wide config were therefore machine-dependent, could inspect real developer databases, and paid an unbounded filesystem-walk cost unrelated to what they were testing.

## Changes

- Pin the process-wide doctor search roots to each test's `tmp_path` with an autouse fixture.
- Register a narrow `doctor_real_search_roots` marker for tests that intentionally exercise production root discovery.
- Explicitly isolate the diagnostics-skeleton helper, which constructs its own `Config` and therefore bypasses the process singleton.
- Add regression coverage that records every `os.walk` root and proves the default doctor check visits exactly the current test temp directory, plus coverage for the marker opt-out.

## Validation

- `/Users/William/.local/bin/uv run --extra dev pytest -q` — 2798 passed, 10 skipped, 5 xfailed
- `/Users/William/.local/bin/uv run --extra dev ruff check palinode/ tests/ scripts/` — passed
- `/Users/William/.local/bin/uv run --extra dev bandit -r palinode/ -ll` — no medium/high findings
- `git diff --check` — passed

## Changelog

`skip-changelog`: this changes test isolation only and does not alter shipping behavior.

## AI disclosure

This change was implemented and validated by an AI coding agent working under the WilliamK112 account.