### PR TITLE
Native Windows: test suite fails on directory fsync and locale-default file encoding

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- **Native Windows memory writes now avoid unsupported directory fsync and
+  preserve overwrite permissions on Python 3.11/3.12.** Source-capture tests
+  read Palinode-written files as UTF-8 instead of using the locale default.
+
 ### Removed
 
 ### Security

--- a/palinode/core/git_tools.py
+++ b/palinode/core/git_tools.py
@@ -106,7 +106,13 @@ def write_memory_file(file_path: str, content: str) -> None:
     fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=prefix, suffix=".tmp")
     try:
         if os.path.exists(file_path):
-            os.fchmod(fd, os.stat(file_path).st_mode & 0o777)
+            mode = os.stat(file_path).st_mode & 0o777
+            fchmod = getattr(os, "fchmod", None)
+            if fchmod is not None:
+                fchmod(fd, mode)
+            else:
+                # ``os.fchmod`` is unavailable on Windows before Python 3.13.
+                os.chmod(tmp_path, mode)
 
         with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
             fd = -1
@@ -115,7 +121,10 @@ def write_memory_file(file_path: str, content: str) -> None:
             os.fsync(tmp_file.fileno())
 
         os.replace(tmp_path, file_path)
-        _fsync_directory(directory)
+        # Windows cannot open a directory for fsync, so the rename's metadata
+        # durability is weaker there after a crash.
+        if os.name != "nt":
+            _fsync_directory(directory)
     except Exception:
         if fd != -1:
             os.close(fd)

--- a/tests/test_git_tools.py
+++ b/tests/test_git_tools.py
@@ -138,3 +138,25 @@ def test_push_failure_logs_warning(caplog):
         r.levelno == _logging.WARNING and "git push failed" in r.message
         for r in caplog.records
     )
+
+
+def test_write_memory_file_skips_directory_fsync_on_windows(tmp_path, monkeypatch):
+    """Windows cannot open a directory as a file descriptor for fsync."""
+    target = tmp_path / "memory.md"
+    monkeypatch.setattr(git_tools.os, "name", "nt")
+    with patch.object(git_tools, "_fsync_directory") as fsync_directory:
+        git_tools.write_memory_file(str(target), "UTF-8 content: “quotes”\n")
+
+    assert target.read_text(encoding="utf-8") == "UTF-8 content: “quotes”\n"
+    fsync_directory.assert_not_called()
+
+
+def test_write_memory_file_overwrite_works_without_fchmod(tmp_path, monkeypatch):
+    """Python 3.11/3.12 Windows needs the path-based chmod fallback."""
+    target = tmp_path / "memory.md"
+    target.write_text("old\n", encoding="utf-8")
+    monkeypatch.delattr(git_tools.os, "fchmod", raising=False)
+
+    git_tools.write_memory_file(str(target), "new\n")
+
+    assert target.read_text(encoding="utf-8") == "new\n"

--- a/tests/test_source_capture_g1.py
+++ b/tests/test_source_capture_g1.py
@@ -37,7 +37,7 @@ def mock_memory_dir(tmp_path, monkeypatch):
 
 
 def _frontmatter(file_path: str) -> dict:
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         text = f.read()
     parts = text.split("---", 2)
     assert len(parts) >= 3, f"no frontmatter in {file_path}: {text[:120]}"
@@ -58,7 +58,7 @@ def _save(json_body: dict):
 
 
 def test_save_with_sources_round_trips_frontmatter(mock_memory_dir):
-    quote = "the exact cited passage"
+    quote = "the exact cited passage with smart “quotes”"
     res = _save({
         "content": "claim body",
         "type": "Decision",


### PR DESCRIPTION
Addresses #93

Implemented the focused Windows portability fix for [issue #93](https://github.com/phasespace-labs/palinode/issues/93):

- Skips unsupported directory fsync on Windows.
- Falls back from unavailable `os.fchmod` on Python 3.11/3.12.
- Forces UTF-8 in source-capture tests and adds non-ASCII coverage.
- Added changelog entry.

Checks passed: `git diff --check`, AST parsing, compileall, and a Windows portability smoke test.

`pytest`, `ruff`, and `bandit` were unavailable; setup failed because `ensurepip` is missing. No typecheck command is configured. Native Windows CI remains unverified. No commit created.