### PR TITLE
ci: upload security scan reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,19 @@ jobs:
           pip install bandit pip-audit
 
       - name: Run bandit (static security analysis)
-        run: bandit -r palinode/ -ll -f json -o bandit-report.json
+        run: |
+          status=0
+          bandit -r palinode/ -ll || status=$?
+          bandit -r palinode/ -ll -f json -o bandit-report.json || status=$?
+          exit "$status"
         continue-on-error: true
 
       - name: Run pip-audit (dependency vulnerability check)
-        run: pip-audit -f json -o pip-audit-report.json
+        run: |
+          status=0
+          pip-audit || status=$?
+          pip-audit -f json -o pip-audit-report.json || status=$?
+          exit "$status"
         continue-on-error: true
 
       - name: Upload security scan reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,12 +91,22 @@ jobs:
           pip install bandit pip-audit
 
       - name: Run bandit (static security analysis)
-        run: bandit -r palinode/ -ll
+        run: bandit -r palinode/ -ll -f json -o bandit-report.json
         continue-on-error: true
 
       - name: Run pip-audit (dependency vulnerability check)
-        run: pip-audit
+        run: pip-audit -f json -o pip-audit-report.json
         continue-on-error: true
+
+      - name: Upload security scan reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-scan-reports
+          path: |
+            bandit-report.json
+            pip-audit-report.json
+          if-no-files-found: warn
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #71

## Why
The security scan preserved scanner exit status but not findings. Contributors had to reproduce CI locally to inspect Bandit and pip-audit results.

## Changes
- write Bandit results to `bandit-report.json`
- write pip-audit results to `pip-audit-report.json`
- upload both as `security-scan-reports` under `if: always()`
- keep the existing `continue-on-error` behavior and warn if a scanner cannot produce a file

## Validation
- workflow YAML parsed successfully
- actual Bandit JSON command produced valid JSON (47,588 bytes)
- actual pip-audit JSON command produced valid JSON (67,419 bytes), including when it exited 1 for findings
- full pytest: 2796 passed, 10 skipped, 5 xfailed
- full Ruff check passed
- `git diff --check` passed

## Changelog
`skip-changelog`: CI-only change

## AI disclosure
This change was implemented and validated by an AI coding agent working under the WilliamK112 account.