### PR TITLE
test: make live search result self-contained

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- **The live search smoke test is now self-contained.** It saves and queries a
+  unique marker instead of depending on unrelated content already being present
+  in the tested instance.
+
 - **Native Windows memory writes now avoid unsupported directory fsync and
   preserve overwrite permissions on Python 3.11/3.12.** Source-capture tests
   read Palinode-written files as UTF-8 instead of using the locale default.

--- a/tests/live/test_live_instance.py
+++ b/tests/live/test_live_instance.py
@@ -159,11 +159,28 @@ class TestSearch:
 
     @pytest.mark.slow
     def test_search_returns_results(self):
-        """Search for something that should exist in any palinode instance."""
-        resp = client.post("/search", json={"query": "palinode memory", "limit": 3})
-        assert resp.status_code == 200
-        results = resp.json()
-        assert len(results) > 0, "Search returned no results"
+        """Search returns content created by this test, not ambient instance data."""
+        unique = f"xyzzy-{_TEST_PREFIX}-search-result"
+        save_resp = client.post("/save", json={
+            "content": f"Live test: {unique}. This phrase belongs to the search result test.",
+            "type": "Insight",
+            "slug": f"{_TEST_PREFIX}-search-result",
+        })
+        assert save_resp.status_code == 200
+
+        # Poll for up to 30s — watcher indexing is asynchronous.
+        for _attempt in range(6):
+            time.sleep(5)
+            resp = client.post("/search", json={"query": unique, "limit": 3})
+            assert resp.status_code == 200
+            results = resp.json()
+            if any(unique in result.get("content", "") for result in results):
+                break
+        else:
+            pytest.fail(
+                f"Search did not return the memory containing '{unique}' after 30s — "
+                "watcher may not be running or Ollama unreachable"
+            )
 
     @pytest.mark.slow
     def test_search_has_score_fields(self):

--- a/tests/live/test_live_instance.py
+++ b/tests/live/test_live_instance.py
@@ -167,19 +167,28 @@ class TestSearch:
             "slug": f"{_TEST_PREFIX}-search-result",
         })
         assert save_resp.status_code == 200
+        save_data = save_resp.json()
 
-        # Poll for up to 30s — watcher indexing is asynchronous.
-        for _attempt in range(6):
-            time.sleep(5)
+        # API saves index inline when possible. Only poll for the watcher fallback
+        # when the save response says inline indexing was deferred.
+        search_attempts = (
+            1 if save_data.get("indexed") or save_data.get("embedded") else 7
+        )
+        for attempt in range(search_attempts):
             resp = client.post("/search", json={"query": unique, "limit": 3})
             assert resp.status_code == 200
             results = resp.json()
             if any(unique in result.get("content", "") for result in results):
                 break
+            if attempt < search_attempts - 1:
+                time.sleep(5)
         else:
+            waited_seconds = (search_attempts - 1) * 5
             pytest.fail(
-                f"Search did not return the memory containing '{unique}' after 30s — "
-                "watcher may not be running or Ollama unreachable"
+                f"Search did not return the memory containing '{unique}' after "
+                f"{waited_seconds}s — save indexed={save_data.get('indexed')}, "
+                f"embedded={save_data.get('embedded')}, "
+                f"index_error={save_data.get('index_error')!r}"
             )
 
     @pytest.mark.slow


### PR DESCRIPTION
## Why

The live search smoke searched for fixed ambient content that it never created, so its outcome depended on what happened to be stored in the target instance.

Closes #96.

## What changed

- save a memory containing a per-run marker before searching
- use the `/save` inline-index result to search immediately when indexing completed
- fall back to a bounded 30-second watcher poll only when inline indexing was deferred, with the first search before any sleep
- include `indexed`, `embedded`, and `index_error` from the save response in failures
- document the test correction under Unreleased

## Validation

- fresh local API with 0 files / 0 chunks and an Ollama-compatible HTTP embedding endpoint: focused live test passes immediately (1 passed in 0.19s)
- isolated control-flow validation: inline/no-sleep, deferred retry, and 30-second diagnostic failure paths pass
- full default suite: 2804 passed, 8 skipped, 5 xfailed
- `ruff check palinode/ tests/ scripts/`
- `bandit -r palinode/ -ll` (0 medium/high findings)
- `git diff --check`
