### PR TITLE
fix: use parser.split_frontmatter in cli/read.py (#100)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- **`palinode read` frontmatter stripping.** Using `parser.split_frontmatter`
+  instead of splitting on the first two `---` occurrences preserves the body when
+  frontmatter values contain `---` sequences.
 - **Native Windows memory writes now avoid unsupported directory fsync and
   preserve overwrite permissions on Python 3.11/3.12.** Source-capture tests
   read Palinode-written files as UTF-8 instead of using the locale default.

--- a/palinode/cli/read.py
+++ b/palinode/cli/read.py
@@ -16,6 +16,7 @@ import click
 
 from palinode.cli._api import HTTPStatusError, api_client
 from palinode.cli._format import OutputFormat, get_default_format
+from palinode.core.parser import split_frontmatter
 
 
 @click.command()
@@ -86,16 +87,6 @@ def _format_with_meta(result: dict) -> str:
     # When meta=True, the API returns the full file content (frontmatter +
     # body).  Strip the leading frontmatter block for cleaner CLI output.
     content = result.get("content", "")
-    body = _strip_frontmatter(content)
+    _, body = split_frontmatter(content)
     lines.append(body)
     return "\n".join(lines)
-
-
-def _strip_frontmatter(content: str) -> str:
-    """If `content` starts with `---`, drop the frontmatter block."""
-    if not content.startswith("---"):
-        return content
-    parts = content.split("---", 2)
-    if len(parts) < 3:
-        return content
-    return parts[2].lstrip("\n")

--- a/tests/test_cli_read_frontmatter.py
+++ b/tests/test_cli_read_frontmatter.py
@@ -1,0 +1,69 @@
+"""Unit tests for `palinode read` frontmatter handling in `cli/read.py`.
+
+Issue #100: `palinode read` was mangling the body when frontmatter values contained `---`.
+Replacing the hand-rolled `_strip_frontmatter` helper with `parser.split_frontmatter`
+ensures the frontmatter block is cleanly stripped based on YAML boundary regex rather than
+naively splitting on the first two `---` occurrences anywhere in the content string.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+from click.testing import CliRunner
+
+from palinode.cli.read import _format_with_meta, read
+
+
+def test_format_with_meta_preserves_body_when_frontmatter_contains_dashes():
+    """When a frontmatter field contains `---`, _format_with_meta must preserve the full body."""
+    raw_content = (
+        "---\n"
+        "title: 'Design --- Architecture ---\'\n"
+        "description: 'A quote anchor containing --- sequence'\n"
+        "---\n"
+        "This is the actual document body.\n"
+        "It also has a --- line inside the body.\n"
+    )
+    result = {
+        "frontmatter": {
+            "title": "Design --- Architecture ---",
+            "description": "A quote anchor containing --- sequence",
+        },
+        "content": raw_content,
+    }
+
+    formatted = _format_with_meta(result)
+
+    assert "── Frontmatter ──" in formatted
+    assert "title: Design --- Architecture ---" in formatted
+    assert "── Content ──" in formatted
+    assert "This is the actual document body." in formatted
+    assert "It also has a --- line inside the body." in formatted
+
+    # The body after "── Content ──" must be the intact body content,
+    # not a truncated/mangled piece of the frontmatter.
+    content_part = formatted.split("── Content ──\n")[1]
+    assert content_part == "This is the actual document body.\nIt also has a --- line inside the body.\n"
+
+
+def test_cli_read_meta_with_dashes_in_frontmatter():
+    """`palinode read file.md --meta` CLI invocation correctly handles `---` inside frontmatter."""
+    raw_content = (
+        "---\n"
+        "title: 'Title --- test'\n"
+        "---\n"
+        "Document body line 1.\n"
+        "Document body line 2.\n"
+    )
+    mock_payload = {
+        "frontmatter": {"title": "Title --- test"},
+        "content": raw_content,
+    }
+
+    runner = CliRunner()
+    with patch("palinode.cli.read.api_client.read", return_value=mock_payload) as mock_read:
+        res = runner.invoke(read, ["projects/test.md", "--meta"])
+        assert res.exit_code == 0
+        assert "Title --- test" in res.output
+        assert "Document body line 1." in res.output
+        assert "Document body line 2." in res.output
+        mock_read.assert_called_once_with("projects/test.md", meta=True)


### PR DESCRIPTION
Fixes #100

Replaces hand-rolled _strip_frontmatter in cli/read.py with parser.split_frontmatter.

Why:
The previous implementation in cli/read.py split on the first two occurrences of three dashes anywhere in the string. When frontmatter contained three dashes inside a value, the split landed inside the frontmatter block and mangled the body.

Using parser.split_frontmatter uses the proper regex boundary matching frontmatter delimiters, leaving the body intact.

Changes:
- Replaced _strip_frontmatter in cli/read.py with parser.split_frontmatter.
- Added tests in tests/test_cli_read_frontmatter.py covering format_with_meta and CLI read.
- Added CHANGELOG entry under Unreleased Fixed section.

Verification:
- Ran pytest (2801 passed).
- Ran ruff check and bandit (all checks passed).