### PR TITLE
test: prearm fixture state cleanup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,16 +60,16 @@ def _isolate_global_config():
 
     ``palinode.core.config.config`` is a module-level singleton that ~30 fixtures
     across the suite mutate (``config.memory_dir``, ``config.git.auto_commit``, …)
-    and then restore with plain statements after a bare ``yield``. Those restores
-    are skipped when the test fails, so **one failure silently reconfigures every
-    later test** — pointing ``memory_dir`` at a deleted ``tmp_path`` or leaving
-    ``git.auto_commit`` off. That turns a single red test into a cascade of
-    unrelated red tests and makes outcomes depend on ordering.
+    and often restore themselves after ``yield``. Pytest runs that teardown after
+    a test-body failure, but cannot register it when fixture setup mutates config
+    and then raises before reaching ``yield``. Without this earlier safety net,
+    that narrower failure can point later tests at a deleted ``tmp_path`` or
+    leave ``git.auto_commit`` off.
 
     This runs before any test-module fixture and restores in a ``finally``, so
-    the leak cannot escape a test regardless of how it ends. It is a safety net,
-    not a licence: a fixture that mutates global state should still use
-    ``monkeypatch`` or ``try/finally``.
+    the setup-failure leak cannot escape a test. It is a safety net, not a
+    licence: a fixture that mutates global state should still use ``monkeypatch``
+    or register a finalizer before its first mutation.
     """
     from palinode.core.config import config
 
@@ -112,6 +112,23 @@ def _warm_embed_gate(monkeypatch):
     from palinode.indexer import reconcile as reconcile_mod
 
     monkeypatch.setattr(reconcile_mod, "_embeds_deferred", lambda client: False)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_rate_counters(request: pytest.FixtureRequest) -> dict:
+    """Clear the process-wide limiter while arming restoration first."""
+    from palinode.api import rate_limit
+
+    counters = rate_limit._rate_counters
+    saved = counters.copy()
+
+    def restore() -> None:
+        counters.clear()
+        counters.update(saved)
+
+    request.addfinalizer(restore)
+    counters.clear()
+    return counters
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_cold_save_fast_return.py
+++ b/tests/test_cold_save_fast_return.py
@@ -42,12 +42,9 @@ def tmp_store(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def _reset_probe_cache():
-    reconcile_mod._probe_cache["ts"] = 0.0
-    reconcile_mod._probe_cache["ok"] = None
-    yield
-    reconcile_mod._probe_cache["ts"] = 0.0
-    reconcile_mod._probe_cache["ok"] = None
+def _reset_probe_cache(monkeypatch):
+    monkeypatch.setitem(reconcile_mod._probe_cache, "ts", 0.0)
+    monkeypatch.setitem(reconcile_mod._probe_cache, "ok", None)
 
 
 def _write_md(tmp_path) -> str:

--- a/tests/test_db_disambiguation.py
+++ b/tests/test_db_disambiguation.py
@@ -23,15 +23,13 @@ from palinode.core.config import config
 
 
 @pytest.fixture(autouse=True)
-def _reset_db_checked():
+def _reset_db_checked(monkeypatch):
     """Reset the module-level _db_checked flag before and after each test.
 
     Without this, the first test that triggers ``_ensure_db`` would mark the
     flag True and all subsequent tests would skip the check entirely.
     """
-    store._db_checked = False
-    yield
-    store._db_checked = False
+    monkeypatch.setattr(store, "_db_checked", False)
 
 
 @pytest.fixture()

--- a/tests/test_demand_decay_importance.py
+++ b/tests/test_demand_decay_importance.py
@@ -113,12 +113,11 @@ def _isolated_env(tmp_path, monkeypatch):
     monkeypatch.setattr(config.decay, "importance_cap", 0.95)
     monkeypatch.setattr(config.decay, "importance_alpha", 0.08)
     monkeypatch.setattr(config.decay, "importance_tau_days", 14.0)
-    store._db_checked = False
+    monkeypatch.setattr(store, "_db_checked", False)
     for d in ("insights", "projects"):
         os.makedirs(os.path.join(memory_dir, d), exist_ok=True)
     store.init_db()
     yield memory_dir
-    store._db_checked = False
 
 
 # ── (a) explicit nudges; passive does NOT ────────────────────────────────────

--- a/tests/test_entity_aliases.py
+++ b/tests/test_entity_aliases.py
@@ -180,11 +180,10 @@ def store_db(tmp_path, monkeypatch):
 
     monkeypatch.setattr(cfg, "memory_dir", str(tmp_path))
     monkeypatch.setattr(cfg, "db_path", str(tmp_path / ".palinode.db"))
-    store._db_checked = False
+    monkeypatch.setattr(store, "_db_checked", False)
     store.init_db()
     aliases.reset_cache()
     yield store
-    store._db_checked = False
 
 
 def test_a_split_subject_answers_as_one_after_mapping(store_db, tmp_path: Path) -> None:

--- a/tests/test_first_run_ux.py
+++ b/tests/test_first_run_ux.py
@@ -79,13 +79,11 @@ class _FakeClient:
 
 
 @pytest.fixture(autouse=True)
-def _reset_embed_cache():
+def _reset_embed_cache(monkeypatch):
     from palinode.api.routers import health
-    health._embed_probe_cache["ts"] = 0.0
-    health._embed_probe_cache["ok"] = None
-    yield
-    health._embed_probe_cache["ts"] = 0.0
-    health._embed_probe_cache["ok"] = None
+
+    monkeypatch.setitem(health._embed_probe_cache, "ts", 0.0)
+    monkeypatch.setitem(health._embed_probe_cache, "ok", None)
 
 
 def test_embed_functional_cached_reflects_probe_and_caches():

--- a/tests/test_hybrid_threshold_rank_artifact.py
+++ b/tests/test_hybrid_threshold_rank_artifact.py
@@ -83,11 +83,10 @@ def _isolated_env(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "db_path", db_path)
     monkeypatch.setattr(config.git, "auto_commit", False)
     monkeypatch.setattr(config.decay, "enabled", False)
-    store._db_checked = False
+    monkeypatch.setattr(store, "_db_checked", False)
     os.makedirs(os.path.join(memory_dir, "insights"), exist_ok=True)
     store.init_db()
     yield memory_dir
-    store._db_checked = False
 
 
 def test_search_hybrid_not_capped_at_rank_locked_ceiling():

--- a/tests/test_recall_feedback.py
+++ b/tests/test_recall_feedback.py
@@ -77,12 +77,11 @@ def _isolated_env(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "memory_dir", memory_dir)
     monkeypatch.setattr(config, "db_path", db_path)
     monkeypatch.setattr(config.git, "auto_commit", False)
-    store._db_checked = False
+    monkeypatch.setattr(store, "_db_checked", False)
     for d in ("insights", "projects"):
         os.makedirs(os.path.join(memory_dir, d), exist_ok=True)
     store.init_db()
     yield memory_dir
-    store._db_checked = False
 
 
 # ── (a) a search stamps exactly the hit chunks ───────────────────────────────

--- a/tests/test_reindex_concurrency.py
+++ b/tests/test_reindex_concurrency.py
@@ -29,21 +29,12 @@ from palinode.core.config import config
 
 
 @pytest.fixture(autouse=True)
-def _reset_reindex_state():
+def _reset_reindex_state(monkeypatch):
     """Ensure _reindex_state is clean before and after every test."""
-    srv._reindex_state.update({
-        "running": False,
-        "started_at": None,
-        "files_processed": 0,
-        "total_files": 0,
-    })
-    yield
-    srv._reindex_state.update({
-        "running": False,
-        "started_at": None,
-        "files_processed": 0,
-        "total_files": 0,
-    })
+    monkeypatch.setitem(srv._reindex_state, "running", False)
+    monkeypatch.setitem(srv._reindex_state, "started_at", None)
+    monkeypatch.setitem(srv._reindex_state, "files_processed", 0)
+    monkeypatch.setitem(srv._reindex_state, "total_files", 0)
 
 
 @pytest.fixture()

--- a/tests/test_reindex_gc.py
+++ b/tests/test_reindex_gc.py
@@ -10,10 +10,8 @@ from palinode.core.config import config
 
 
 @pytest.fixture(autouse=True)
-def _reset_db_checked():
-    store._db_checked = False
-    yield
-    store._db_checked = False
+def _reset_db_checked(monkeypatch):
+    monkeypatch.setattr(store, "_db_checked", False)
 
 
 def _chunk(chunk_id: str, file_path: str, content: str) -> dict:

--- a/tests/test_robustness_483.py
+++ b/tests/test_robustness_483.py
@@ -58,7 +58,7 @@ def _isolated_env(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "memory_dir", memory_dir)
     monkeypatch.setattr(config, "db_path", db_path)
     monkeypatch.setattr(config.git, "auto_commit", False)
-    store._db_checked = False
+    monkeypatch.setattr(store, "_db_checked", False)
     store.init_db()
     yield
 

--- a/tests/test_search_internal_guard.py
+++ b/tests/test_search_internal_guard.py
@@ -85,12 +85,11 @@ def _isolated_env(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "memory_dir", memory_dir)
     monkeypatch.setattr(config, "db_path", db_path)
     monkeypatch.setattr(config.git, "auto_commit", False)
-    store._db_checked = False
+    monkeypatch.setattr(store, "_db_checked", False)
     for d in ("insights",):
         os.makedirs(os.path.join(memory_dir, d), exist_ok=True)
     store.init_db()
     yield memory_dir
-    store._db_checked = False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_security_rate_limit_budget.py
+++ b/tests/test_security_rate_limit_budget.py
@@ -19,14 +19,10 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _isolate_rate_counters():
+def _isolate_rate_counters(_isolated_rate_counters):
     from palinode.api import server
 
-    saved = server._rate_counters.copy()
-    server._rate_counters.clear()
-    yield server
-    server._rate_counters.clear()
-    server._rate_counters.update(saved)
+    return server
 
 
 def test_counter_tracks_admissions_not_attempts(_isolate_rate_counters) -> None:

--- a/tests/test_security_rate_limit_pruning.py
+++ b/tests/test_security_rate_limit_pruning.py
@@ -7,14 +7,10 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def _isolate_rate_counters():
+def _isolate_rate_counters(_isolated_rate_counters):
     from palinode.api import server
 
-    saved = server._rate_counters.copy()
-    server._rate_counters.clear()
-    yield server
-    server._rate_counters.clear()
-    server._rate_counters.update(saved)
+    return server
 
 
 def test_expired_entries_pruned_on_check(_isolate_rate_counters) -> None:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -10,10 +10,9 @@ def tmp_store_db(tmp_path, monkeypatch):
     db_path = tmp_path / ".palinode.db"
     monkeypatch.setattr(config, "memory_dir", str(tmp_path))
     monkeypatch.setattr(config, "db_path", str(db_path))
-    store._db_checked = False
+    monkeypatch.setattr(store, "_db_checked", False)
     store.init_db()
     yield
-    store._db_checked = False
 
 
 def _entity_refs_for_path(file_path: str) -> list[str]:

--- a/tests/test_suite_isolation.py
+++ b/tests/test_suite_isolation.py
@@ -4,11 +4,10 @@ Two failure modes live here, both siblings of the "exit 134 after everything
 passed":
 
 1. **Global config leaking across tests.** ``palinode.core.config.config`` is a
-   process-wide singleton that ~30 fixtures mutate and restore with plain
-   statements after a bare ``yield``. Those restores are skipped on failure, so
-   one red test silently reconfigures every test after it — a single failure
-   fans out into unrelated failures, and outcomes start depending on ordering.
-   ``tests/conftest.py::_isolate_global_config`` restores it in a ``finally``.
+   process-wide singleton that ~30 fixtures mutate. Yield-fixture teardown runs
+   after test-body failures, but is not registered if setup raises before its
+   ``yield``. ``tests/conftest.py::_isolate_global_config`` starts first and
+   restores config in a ``finally``, covering that setup-failure window.
 
 2. **Colour-forcing environment.** ``rich`` colourises when ``FORCE_COLOR`` or
    ``CLICOLOR_FORCE`` is merely *present*, so a developer with either exported
@@ -22,6 +21,8 @@ import os
 import pytest
 
 from palinode.core.config import config
+
+pytest_plugins = ("pytester",)
 
 
 class TestGlobalConfigIsolation:
@@ -60,3 +61,31 @@ def test_colour_forcing_env_is_neutralised() -> None:
     assert "FORCE_COLOR" not in os.environ
     assert "CLICOLOR_FORCE" not in os.environ
     assert os.environ.get("NO_COLOR")
+
+
+def test_prearmed_finalizer_runs_after_fixture_setup_failure(pytester) -> None:
+    """Cleanup registered before mutation survives an exception before yield."""
+    pytester.makepyfile(
+        """
+        import pytest
+
+        state = []
+
+        @pytest.fixture
+        def mutates_then_fails(request):
+            request.addfinalizer(state.clear)
+            state.append("leaked")
+            raise RuntimeError("fixture setup failed before yield")
+            yield
+
+        @pytest.mark.xfail(raises=RuntimeError, strict=True)
+        def test_1_setup_failure(mutates_then_fails):
+            pass
+
+        def test_2_following_test_sees_clean_state():
+            assert state == []
+        """
+    )
+
+    result = pytester.runpytest("-q")
+    result.assert_outcomes(passed=1, xfailed=1)

--- a/tests/test_telemetry_recall_exclusion.py
+++ b/tests/test_telemetry_recall_exclusion.py
@@ -68,12 +68,11 @@ def _isolated_env(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "memory_dir", memory_dir)
     monkeypatch.setattr(config, "db_path", db_path)
     monkeypatch.setattr(config.git, "auto_commit", False)
-    store._db_checked = False
+    monkeypatch.setattr(store, "_db_checked", False)
     for d in ("inbox", "insights"):
         os.makedirs(os.path.join(memory_dir, d), exist_ok=True)
     store.init_db()
     yield memory_dir
-    store._db_checked = False
 
 
 # ── (c) telemetry is excluded from default vector search ─────────────────────

--- a/tests/test_visibility_scopes.py
+++ b/tests/test_visibility_scopes.py
@@ -591,7 +591,7 @@ def recall_widen_db(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "memory_dir", memory_dir)
     monkeypatch.setattr(config, "db_path", os.path.join(memory_dir, ".palinode.db"))
     monkeypatch.setattr(config.git, "auto_commit", False)
-    store._db_checked = False
+    monkeypatch.setattr(store, "_db_checked", False)
     os.makedirs(os.path.join(memory_dir, "insights"), exist_ok=True)
     store.init_db()
 
@@ -620,7 +620,6 @@ def recall_widen_db(tmp_path, monkeypatch):
         _write_and_index(r, f"name: Visible{r}\n")
 
     yield memory_dir
-    store._db_checked = False
 
 
 def test_widened_fetch_counts_recall_once(recall_widen_db):


### PR DESCRIPTION
Closes #85

## Why
Pytest resumes generator fixtures after a test-body failure, but teardown is never registered when fixture setup mutates shared module state and then raises before reaching `yield`. That narrower window could leak state into later tests.

## Changes
- add an autouse rate-counter isolation fixture that registers restoration before clearing the shared mapping
- use `monkeypatch` for embed caches, reindex progress, and `_db_checked` fixture state so restoration is armed before mutation
- correct `_isolate_global_config` and suite-isolation documentation to describe setup failures accurately
- add a pytester regression where fixture setup mutates state and raises before `yield`, then verify the following test sees clean state

## Validation
- full pytest: 2799 passed, 10 skipped, 5 xfailed
- focused affected tests: 183 passed, 1 xfailed
- full Ruff check passed
- Bandit: no medium/high findings
- `git diff --check` passed

## Changelog
`skip-changelog`: test-hygiene-only change

## AI disclosure
This change was implemented and validated by an AI coding agent working under the WilliamK112 account.