### PR TITLE
test: pin doctor context search roots

### DIFF
--- a/tests/test_doctor_path_checks.py
+++ b/tests/test_doctor_path_checks.py
@@ -51,9 +51,19 @@ def _ctx(
         memory_dir=str(memory_dir),
         db_path=str(resolved_db),
     )
-    if search_roots is not None:
-        cfg.doctor.search_roots = search_roots
+    cfg.doctor.search_roots = (
+        search_roots if search_roots is not None else [str(memory_dir)]
+    )
     return DoctorContext(config=cfg)
+
+
+def test_ctx_defaults_search_roots_to_memory_dir(tmp_path: Path) -> None:
+    """Synthetic contexts never fall back to machine-wide discovery roots."""
+    memory_dir = tmp_path / "palinode"
+
+    ctx = _ctx(memory_dir)
+
+    assert ctx.config.doctor.search_roots == [str(memory_dir)]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #92 and the non-blocking maintainer note in https://github.com/phasespace-labs/palinode/pull/92#issuecomment-5234626612.

## Why
`tests/test_doctor_path_checks.py::_ctx` was the remaining synthetic `DoctorContext` helper whose default `search_roots` stayed empty. Its current phantom-DB call sites pass roots explicitly, but a future caller could otherwise reintroduce machine-wide filesystem discovery.

## Changes
- default `_ctx` search roots to its temporary `memory_dir`
- preserve explicitly supplied roots for discovery-specific tests
- add a direct regression for the helper default

## Validation
- focused doctor tests: 28 passed
- full pytest: 2803 passed, 10 skipped, 5 xfailed
- full Ruff check passed
- Bandit: no medium/high findings
- `git diff --check` passed

## Changelog
`skip-changelog`: test-hygiene-only change

## AI disclosure
This change was implemented and validated by an AI coding agent working under the WilliamK112 account.