### PR TITLE
fix: return 503 when search embeddings are unavailable

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,10 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 - **The live search smoke test is now self-contained.** It saves and queries a
   unique marker instead of depending on unrelated content already being present
   in the tested instance.
+- **Embedding-dependent search now reports unavailable backends as HTTP 503
+  instead of an internal-server error.** API, CLI, and MCP callers preserve
+  the typed backend/model diagnostic and `palinode doctor` recovery hint,
+  while save continues to succeed with its existing deferred-index warning.
 
 - **Native Windows memory writes now avoid unsupported directory fsync and
   preserve overwrite permissions on Python 3.11/3.12.** Source-capture tests

--- a/palinode/api/routers/search.py
+++ b/palinode/api/routers/search.py
@@ -30,6 +30,18 @@ router = APIRouter()
 _VISIBILITY_OVERFETCH = 5
 
 
+def _embedding_unavailable_503(
+    error: embedder.EmbeddingUnavailable,
+    operation: str,
+) -> HTTPException:
+    """Preserve the typed outage message without logging a traceback."""
+    logger.warning(
+        "%s unavailable op=search outcome=embedding_unavailable",
+        operation,
+    )
+    return HTTPException(status_code=503, detail=str(error))
+
+
 def _resolve_scope_chain(
     context: list[str] | None = None,
     session_id: str | None = None,
@@ -404,6 +416,8 @@ def search_api(req: SearchRequest, request: Request = None) -> list[dict[str, An
             session_id=req.session_id,
         )
         return final
+    except embedder.EmbeddingUnavailable as e:
+        raise _embedding_unavailable_503(e, "Search") from None
     except Exception as e:
         raise _safe_500(e, "Search failed")
 
@@ -493,6 +507,8 @@ def dedup_suggest_api(req: DedupSuggestRequest) -> list[dict[str, Any]]:
         for r in ranked:
             r["strong_dup"] = r["similarity"] >= strong_threshold
         return ranked
+    except embedder.EmbeddingUnavailable as e:
+        raise _embedding_unavailable_503(e, "Dedup suggest") from None
     except Exception as e:
         raise _safe_500(e, "Dedup suggest failed")
 
@@ -535,6 +551,8 @@ def orphan_repair_api(req: OrphanRepairRequest) -> list[dict[str, Any]]:
             min_similarity=min_similarity,
             top_k=top_k,
         )
+    except embedder.EmbeddingUnavailable as e:
+        raise _embedding_unavailable_503(e, "Orphan repair") from None
     except Exception as e:
         raise _safe_500(e, "Orphan repair failed")
 
@@ -628,6 +646,8 @@ def cluster_neighbors_api(req: ClusterNeighborsRequest) -> list[dict[str, Any]]:
         for r in ranked:
             r["score"] = r["similarity"]
         return ranked
+    except embedder.EmbeddingUnavailable as e:
+        raise _embedding_unavailable_503(e, "Cluster neighbors") from None
     except Exception as e:
         raise _safe_500(e, "Cluster neighbors failed")
 
@@ -679,5 +699,7 @@ def topic_coverage_api(req: TopicCoverageRequest) -> dict[str, Any]:
                 "similarity": best["similarity"],
             }
         return {"covered": False, "best_match": None, "similarity": 0.0}
+    except embedder.EmbeddingUnavailable as e:
+        raise _embedding_unavailable_503(e, "Topic coverage") from None
     except Exception as e:
         raise _safe_500(e, "Topic coverage failed")

--- a/palinode/cli/search.py
+++ b/palinode/cli/search.py
@@ -1,6 +1,6 @@
 import os
 import click
-from palinode.cli._api import api_client
+from palinode.cli._api import HTTPStatusError, api_client
 from palinode.cli._format import print_result, console, OutputFormat, get_default_format
 from palinode.core.config import config
 from palinode.core.parity import CATEGORIES, MEMORY_TYPES
@@ -141,6 +141,14 @@ def search(
                 console.print(f"  {body}")
                 console.print()
                 
+    except HTTPStatusError as e:
+        detail = ""
+        try:
+            detail = e.response.json().get("detail", "")
+        except Exception:
+            pass
+        console.print(f"[red]Error searching memory:[/red] {detail or str(e)}")
+        click.Abort()
     except Exception as e:
         console.print(f"[red]Error searching memory: {str(e)}[/red]")
         click.Abort()

--- a/tests/test_search_embedder_outage.py
+++ b/tests/test_search_embedder_outage.py
@@ -1,27 +1,25 @@
-"""Regression: /search must surface an embedder outage as an error, not a
-silent empty result set.
+"""Embedding-dependent search surfaces preserve typed outage diagnostics."""
 
-Before this fix, `embedder.embed()` returned `[]` on a backend failure and
-`search_api` treated that identically to "the embedder is fine but this query
-happens to have no results" (`if not query_emb: return []`) — HTTP 200 with an
-empty list, indistinguishable from a genuine no-match. Every route in
-`palinode/api/routers/search.py` already wraps its body in a broad
-`except Exception as e: raise _safe_500(e, ...)`, so once `embed()` raises
-instead of returning falsy, the failure now surfaces as a proper 500 with the
-real cause logged server-side — no code change needed in the routers
-themselves, which is the point of fixing the contract at the boundary.
-"""
 from __future__ import annotations
 
+import importlib
+import logging
 from unittest.mock import patch
 
+import httpx
 import pytest
+from click.testing import CliRunner
 from fastapi.testclient import TestClient
 
+import palinode.core.embedder as embedder_mod
+import palinode.core.ollama_client as ollama_client_mod
+import palinode.mcp as mcp
 from palinode.api import server as srv
 from palinode.api.server import app
 from palinode.core.config import config
 from palinode.core.embedder import EmbeddingUnavailable
+from palinode.core.ollama_client import OllamaClient, RetryPolicy
+from palinode.mcp import _dispatch_tool
 
 
 @pytest.fixture()
@@ -29,31 +27,105 @@ def client(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "memory_dir", str(tmp_path))
     monkeypatch.setattr(config, "db_path", str(tmp_path / ".palinode.db"))
     monkeypatch.setattr(config.git, "auto_commit", False)
+    monkeypatch.setattr(config.auto_summary, "enabled", False)
     srv._rate_counters.clear()
     with TestClient(app, raise_server_exceptions=False) as c:
         yield c
     srv._rate_counters.clear()
 
 
+@pytest.fixture()
+def dead_embedder(monkeypatch):
+    """Use the real HTTP client against a loopback port with no listener."""
+    dead_client = OllamaClient(retry_policy=RetryPolicy(retries=0))
+    monkeypatch.setattr(config.embeddings.primary, "url", "http://127.0.0.1:1")
+    monkeypatch.setattr(config.embeddings.primary, "connect_timeout_seconds", 1)
+    monkeypatch.setattr(config.embeddings.primary, "timeout_seconds", 1)
+    monkeypatch.setattr(ollama_client_mod, "_singleton", dead_client)
+    # The context-size probe is a separate diagnostic request. Skip it so this
+    # integration test exercises exactly the search embedding call.
+    monkeypatch.setattr(embedder_mod, "_preflight_done", True)
+    yield
+    dead_client.close()
+
+
 def _boom(text, backend="local"):
     raise EmbeddingUnavailable(
-        backend="local", model="bge-m3", text_len=len(text),
+        backend="local",
+        model="bge-m3",
+        text_len=len(text),
         cause="connection refused",
     )
 
 
-def test_search_surfaces_500_instead_of_silent_empty_result(client):
-    with patch("palinode.core.embedder.embed", side_effect=_boom):
-        res = client.post("/search", json={"query": "does this exist"})
-    assert res.status_code == 500
-    assert res.json()["detail"] == "Search failed"
+def test_search_dead_embedder_returns_typed_503_without_api_traceback(
+    client, dead_embedder, caplog
+):
+    sensitive_query = "PRIVATE_QUERY_MUST_NOT_APPEAR_IN_DIAGNOSTICS"
+    with caplog.at_level(logging.WARNING):
+        res = client.post("/search", json={"query": sensitive_query})
+
+    assert res.status_code == 503
+    detail = res.json()["detail"]
+    assert "Embedding backend unavailable" in detail
+    assert "backend=local" in detail
+    assert "model='bge-m3'" in detail
+    assert "palinode doctor" in detail
+    assert sensitive_query not in detail
+
+    route_warnings = [
+        record
+        for record in caplog.records
+        if record.name == "palinode.api"
+        and "outcome=embedding_unavailable" in record.getMessage()
+    ]
+    assert len(route_warnings) == 1
+    assert route_warnings[0].exc_info is None
+    assert "cause=" not in route_warnings[0].getMessage()
+    assert sensitive_query not in caplog.text
+    assert "Traceback" not in caplog.text
 
 
-def test_dedup_suggest_surfaces_500_instead_of_silent_empty_result(client):
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        ("/dedup-suggest", {"content": "some draft content"}),
+        ("/orphan-repair", {"broken_link": "missing target"}),
+        ("/cluster-neighbors", {"file_path": "insights/source.md"}),
+        ("/topic-coverage", {"query": "deployment policy"}),
+    ],
+)
+def test_other_embedding_search_operations_preserve_typed_503(
+    client, tmp_path, path, payload
+):
+    source = tmp_path / "insights" / "source.md"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("Semantic source body.", encoding="utf-8")
+
     with patch("palinode.core.embedder.embed", side_effect=_boom):
-        res = client.post("/dedup-suggest", json={"content": "some draft content"})
-    assert res.status_code == 500
-    assert res.json()["detail"] == "Dedup suggest failed"
+        res = client.post(path, json=payload)
+
+    assert res.status_code == 503
+    assert "Embedding backend unavailable" in res.json()["detail"]
+    assert "palinode doctor" in res.json()["detail"]
+
+
+def test_save_keeps_200_and_index_error_with_same_dead_embedder(client, dead_embedder):
+    res = client.post(
+        "/save",
+        json={
+            "content": "Save succeeds even while semantic indexing is offline.",
+            "type": "Insight",
+            "slug": "dead-embedder-save-regression",
+        },
+    )
+
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["indexed"] is False
+    assert body["embedded"] is False
+    assert "embedder unreachable" in body["index_error"]
+    assert "retry" in body["index_error"]
 
 
 def test_search_empty_query_bypasses_embedder_entirely(client):
@@ -63,3 +135,37 @@ def test_search_empty_query_bypasses_embedder_entirely(client):
         res = client.post("/search", json={"query": ""})
     assert res.status_code == 200
     assert res.json() == []
+
+
+def test_cli_search_relays_typed_503_message():
+    search_cli = importlib.import_module("palinode.cli.search")
+    detail = "Embedding backend unavailable — run `palinode doctor`"
+    request = httpx.Request("POST", "http://palinode.test/search")
+    response = httpx.Response(503, json={"detail": detail}, request=request)
+    error = httpx.HTTPStatusError(
+        "503 Service Unavailable", request=request, response=response
+    )
+
+    with patch.object(search_cli.api_client, "search", side_effect=error):
+        result = CliRunner().invoke(search_cli.search, ["anything"])
+
+    assert detail in result.output
+    assert "Internal Server Error" not in result.output
+
+
+@pytest.mark.asyncio
+async def test_mcp_search_relays_typed_503_message(monkeypatch):
+    detail = "Embedding backend unavailable — run `palinode doctor`"
+
+    class UnavailableResponse:
+        status_code = 503
+        text = '{"detail":"Embedding backend unavailable — run `palinode doctor`"}'
+
+    async def unavailable_post(*args, **kwargs):
+        return UnavailableResponse()
+
+    monkeypatch.setattr(mcp, "_post", unavailable_post)
+    result = await _dispatch_tool("palinode_search", {"query": "anything"})
+
+    assert detail in result[0].text
+    assert "Internal Server Error" not in result[0].text


### PR DESCRIPTION
Closes #97

## Why

`EmbeddingUnavailable` already carries the actionable backend, model, and `palinode doctor` recovery information, but the search routers' broad exception handling flattened it into a generic 500 and logged a traceback. An offline dependency is a retryable service-availability failure, not an internal application error.

## What changed

- map `EmbeddingUnavailable` to HTTP 503 before the generic catch on every embedding-dependent search endpoint
- emit one concise API warning without a traceback or duplicated cause details; the embedder boundary remains responsible for logging the cause
- preserve the typed 503 detail in the CLI and pin the MCP relay behavior
- exercise `/search` against a real dead Ollama URL with a real temporary SQLite database
- pin `/save`'s deliberate 200 response with `indexed=false`, `embedded=false`, and `index_error`
- add the user-visible behavior to `Unreleased / Fixed`

## Validation

- affected search, MCP, save, and API integration tests: `108 passed`
- full suite: `2808 passed, 10 skipped, 5 xfailed`
- Ruff: all checks passed
- Bandit: 0 medium/high findings
- `git diff --check`: passed

## AI disclosure

I used OpenAI Codex to help inspect the call paths, implement the focused change, and run the validation. I reviewed the final diff and test results before submission.
