### PR TITLE
fix: serialize consolidation runs per memory store

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- **Concurrent consolidation runs now refuse instead of racing over store
+  mutations and git commits.** Weekly and nightly runs share a store-local,
+  stale-recoverable lock across API, CLI/MCP, and cron entry points.
+
 - **The live search smoke test is now self-contained.** It saves and queries a
   unique marker instead of depending on unrelated content already being present
   in the tested instance.

--- a/palinode/api/routers/consolidation.py
+++ b/palinode/api/routers/consolidation.py
@@ -28,6 +28,7 @@ def consolidate_api(req: ConsolidateRequest = None) -> dict[str, Any]:
     for testing or after a busy week.
     """
     from palinode.consolidation.runner import run_consolidation, run_nightly
+    from palinode.consolidation.run_lock import ConsolidationAlreadyRunning
 
     req = req or ConsolidateRequest()
     try:
@@ -36,6 +37,8 @@ def consolidate_api(req: ConsolidateRequest = None) -> dict[str, Any]:
         else:
             result = run_consolidation(dry_run=req.dry_run, sources=req.sources)
         return result
+    except ConsolidationAlreadyRunning as e:
+        raise HTTPException(status_code=409, detail=str(e)) from None
     except Exception as e:
         raise _safe_500(e, "Consolidation failed")
 

--- a/palinode/cli/consolidate.py
+++ b/palinode/cli/consolidate.py
@@ -1,5 +1,5 @@
 import click
-from palinode.cli._api import api_client
+from palinode.cli._api import HTTPStatusError, api_client
 from palinode.cli._format import console, print_result, get_default_format, OutputFormat
 
 @click.command()
@@ -36,6 +36,15 @@ def consolidate(nightly, dry_run, sources, fmt):
                 console.print("[green]Consolidation complete.[/green]")
                 console.print(f"Stats: {data.get('stats', 'none')}")
                 
+    except HTTPStatusError as e:
+        detail = ""
+        try:
+            detail = e.response.json().get("detail", "")
+        except Exception:
+            pass
+        raise click.ClickException(
+            detail or f"Consolidation request failed ({e.response.status_code})"
+        ) from e
     except Exception as e:
         console.print(f"[red]Error consolidating: {str(e)}[/red]")
         click.Abort()

--- a/palinode/consolidation/cron.py
+++ b/palinode/consolidation/cron.py
@@ -20,6 +20,7 @@ import sys
 
 from palinode.core.config import config
 from palinode.consolidation.runner import run_consolidation, run_nightly
+from palinode.consolidation.run_lock import ConsolidationAlreadyRunning
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
 logger = logging.getLogger("palinode.consolidation.cron")
@@ -44,10 +45,14 @@ def main() -> None:
     mode = "nightly" if nightly else "weekly"
     logger.info(f"Starting {mode} consolidation (lookback: {lookback or 'config default'} days)...")
 
-    if nightly:
-        result = run_nightly(lookback_days=lookback)
-    else:
-        result = run_consolidation(lookback_days=lookback)
+    try:
+        if nightly:
+            result = run_nightly(lookback_days=lookback)
+        else:
+            result = run_consolidation(lookback_days=lookback)
+    except ConsolidationAlreadyRunning as error:
+        logger.error("%s", error)
+        raise SystemExit(1) from None
 
     logger.info(f"Consolidation complete: {result}")
 

--- a/palinode/consolidation/run_lock.py
+++ b/palinode/consolidation/run_lock.py
@@ -1,0 +1,258 @@
+"""Cross-process ownership for consolidation runs.
+
+The lock belongs to the memory store, not to a Palinode installation. Every
+public consolidation runner acquires the same file before reading or mutating
+the store, so API, CLI/MCP, and cron entry points cannot race one another.
+"""
+
+from __future__ import annotations
+
+import errno
+import json
+import logging
+import os
+import socket
+import time
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+from palinode.core.config import config
+
+logger = logging.getLogger("palinode.consolidation")
+
+# ``.palinode/`` is the store's existing git-ignored operational directory;
+# watcher/import paths also skip it, so the lock never becomes memory content.
+LOCK_RELATIVE_PATH = Path(".palinode") / "consolidation.lock"
+LOCK_TTL_SECONDS = 6 * 60 * 60
+_MAX_ACQUIRE_ATTEMPTS = 4
+
+
+class ConsolidationAlreadyRunning(RuntimeError):
+    """Raised when another process owns the memory store's run lock."""
+
+
+@dataclass(frozen=True)
+class _LockOwner:
+    path: Path
+    token: str
+
+
+@dataclass(frozen=True)
+class _ObservedLock:
+    metadata: dict[str, object]
+    inode: int
+    mtime_ns: int
+
+
+def consolidation_lock_path(memory_dir: str | os.PathLike[str] | None = None) -> Path:
+    """Return the operational lock path for one configured memory store."""
+    base = memory_dir or getattr(config, "memory_dir", None) or config.palinode_dir
+    return Path(base).expanduser() / LOCK_RELATIVE_PATH
+
+
+def _pid_is_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    if os.name == "nt":
+        # ``os.kill(pid, 0)`` is not a harmless existence probe on Windows:
+        # non-console signals call TerminateProcess. Query a process handle
+        # instead so stale-lock recovery can never kill the alleged owner.
+        import ctypes
+        from ctypes import wintypes
+
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        kernel32.OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+        kernel32.OpenProcess.restype = wintypes.HANDLE
+        kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        kernel32.CloseHandle.restype = wintypes.BOOL
+        handle = kernel32.OpenProcess(0x1000, False, pid)  # PROCESS_QUERY_LIMITED_INFORMATION
+        if handle:
+            kernel32.CloseHandle(handle)
+            return True
+        return ctypes.get_last_error() == 5  # ERROR_ACCESS_DENIED still means it exists.
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError as error:
+        return error.errno != errno.ESRCH
+    return True
+
+
+def _read_lock(path: Path) -> _ObservedLock | None:
+    try:
+        with path.open("rb") as handle:
+            stat = os.fstat(handle.fileno())
+            raw = handle.read()
+    except FileNotFoundError:
+        return None
+    except OSError:
+        # Preserve the stat identity when possible. An unreadable recent lock
+        # must fail closed rather than be treated as stale without evidence.
+        try:
+            stat = path.stat()
+        except FileNotFoundError:
+            return None
+        return _ObservedLock({}, stat.st_ino, stat.st_mtime_ns)
+
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError, UnicodeDecodeError):
+        parsed = {}
+    metadata = parsed if isinstance(parsed, dict) else {}
+    return _ObservedLock(metadata, stat.st_ino, stat.st_mtime_ns)
+
+
+def _lock_age_seconds(observed: _ObservedLock, now: float) -> float:
+    created_at = observed.metadata.get("created_at")
+    try:
+        created = float(created_at)
+    except (TypeError, ValueError):
+        created = observed.mtime_ns / 1_000_000_000
+    return max(0.0, now - created)
+
+
+def _stale_reason(observed: _ObservedLock, now: float) -> str | None:
+    age = _lock_age_seconds(observed, now)
+    owner_host = observed.metadata.get("hostname")
+    owner_pid = observed.metadata.get("pid")
+
+    if owner_host == socket.gethostname():
+        try:
+            pid = int(owner_pid)
+        except (TypeError, ValueError):
+            pid = 0
+        if pid and not _pid_is_alive(pid):
+            return f"owner pid {pid} is no longer running"
+        if pid:
+            # A live local owner wins over age. Consolidation can legitimately
+            # exceed the fallback TTL on a slow model; reclaiming it would
+            # create the mutation race this lock exists to prevent.
+            return None
+
+    if age > LOCK_TTL_SECONDS:
+        return f"lock age {age:.0f}s exceeds TTL {LOCK_TTL_SECONDS}s"
+    return None
+
+
+def _busy_message(observed: _ObservedLock) -> str:
+    metadata = observed.metadata
+    owner_text = (
+        f"pid={metadata['pid']}"
+        if metadata.get("pid") is not None
+        else "owner metadata unavailable"
+    )
+    return (
+        f"Consolidation is already running ({owner_text}; lock={LOCK_RELATIVE_PATH}). "
+        "Wait for it to finish, or reclaim the lock after its owner exits."
+    )
+
+
+def _create_lock(path: Path, now: float) -> _LockOwner:
+    token = uuid.uuid4().hex
+    payload = {
+        "pid": os.getpid(),
+        "hostname": socket.gethostname(),
+        "created_at": now,
+        "token": token,
+    }
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    fd = os.open(path, flags, 0o600)
+    try:
+        encoded = (json.dumps(payload, sort_keys=True) + "\n").encode("utf-8")
+        offset = 0
+        while offset < len(encoded):
+            written = os.write(fd, encoded[offset:])
+            if written == 0:
+                raise OSError("short write while creating consolidation lock")
+            offset += written
+        os.fsync(fd)
+    except BaseException:
+        os.close(fd)
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        raise
+    else:
+        os.close(fd)
+    return _LockOwner(path=path, token=token)
+
+
+def _remove_if_unchanged(path: Path, observed: _ObservedLock) -> bool:
+    current = _read_lock(path)
+    if current is None:
+        return False
+    if (current.inode, current.mtime_ns) != (observed.inode, observed.mtime_ns):
+        return False
+    if current.metadata.get("token") != observed.metadata.get("token"):
+        return False
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def _acquire(memory_dir: str | os.PathLike[str] | None = None) -> _LockOwner:
+    path = consolidation_lock_path(memory_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    for _ in range(_MAX_ACQUIRE_ATTEMPTS):
+        now = time.time()
+        try:
+            return _create_lock(path, now)
+        except FileExistsError:
+            observed = _read_lock(path)
+            if observed is None:
+                continue
+            reason = _stale_reason(observed, now)
+            if reason is None:
+                raise ConsolidationAlreadyRunning(_busy_message(observed))
+            if not _remove_if_unchanged(path, observed):
+                continue
+            logger.warning(
+                "Reclaimed stale consolidation lock path=%s reason=%s",
+                path,
+                reason,
+            )
+
+    observed = _read_lock(path)
+    if observed is not None:
+        raise ConsolidationAlreadyRunning(_busy_message(observed))
+    raise ConsolidationAlreadyRunning(
+        f"Could not acquire consolidation lock after concurrent recovery (lock={path})."
+    )
+
+
+def _release(owner: _LockOwner) -> None:
+    observed = _read_lock(owner.path)
+    if observed is None:
+        return
+    if observed.metadata.get("token") != owner.token:
+        logger.warning(
+            "Did not release consolidation lock owned by another run path=%s",
+            owner.path,
+        )
+        return
+    try:
+        owner.path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+@contextmanager
+def consolidation_run_lock(
+    memory_dir: str | os.PathLike[str] | None = None,
+) -> Iterator[Path]:
+    """Acquire the store-local run lock and always release this ownership."""
+    owner = _acquire(memory_dir)
+    try:
+        yield owner.path
+    finally:
+        _release(owner)

--- a/palinode/consolidation/runner.py
+++ b/palinode/consolidation/runner.py
@@ -837,6 +837,24 @@ def run_consolidation(
     llm_fn: LlmFn | None = None,
     sources: Sequence[str] | None = None,
 ) -> dict[str, Any]:
+    """Run weekly consolidation under the memory store's shared run lock."""
+    from palinode.consolidation.run_lock import consolidation_run_lock
+
+    with consolidation_run_lock():
+        return _run_consolidation_unlocked(
+            lookback_days=lookback_days,
+            dry_run=dry_run,
+            llm_fn=llm_fn,
+            sources=sources,
+        )
+
+
+def _run_consolidation_unlocked(
+    lookback_days: int | None = None,
+    dry_run: bool = False,
+    llm_fn: LlmFn | None = None,
+    sources: Sequence[str] | None = None,
+) -> dict[str, Any]:
     """Orchestrator for the entire memory consolidation process.
 
     ``sources`` selects which directories under ``memory_dir`` to consolidate,
@@ -978,6 +996,18 @@ def run_consolidation(
 
 
 def run_nightly(lookback_days: int | None = None, dry_run: bool = False, llm_fn: LlmFn | None = None) -> dict[str, Any]:
+    """Run nightly consolidation under the memory store's shared run lock."""
+    from palinode.consolidation.run_lock import consolidation_run_lock
+
+    with consolidation_run_lock():
+        return _run_nightly_unlocked(
+            lookback_days=lookback_days,
+            dry_run=dry_run,
+            llm_fn=llm_fn,
+        )
+
+
+def _run_nightly_unlocked(lookback_days: int | None = None, dry_run: bool = False, llm_fn: LlmFn | None = None) -> dict[str, Any]:
     """Lightweight nightly consolidation — process today's daily notes only.
 
     Restricted to UPDATE and SUPERSEDE ops. No ARCHIVE or MERGE (those

--- a/tests/test_consolidation_run_lock.py
+++ b/tests/test_consolidation_run_lock.py
@@ -1,0 +1,285 @@
+"""The store-local consolidation lock is shared by every run surface."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import logging
+import multiprocessing
+import os
+import socket
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+from click.testing import CliRunner
+from fastapi.testclient import TestClient
+
+import palinode.consolidation.cron as cron
+import palinode.consolidation.run_lock as run_lock
+import palinode.consolidation.runner as runner
+import palinode.mcp as mcp
+from palinode.api import server as srv
+from palinode.api.server import app
+from palinode.core.config import config
+from palinode.mcp import _dispatch_tool
+
+
+@pytest.fixture()
+def memory_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "memory_dir", str(tmp_path))
+    monkeypatch.setattr(config, "db_path", str(tmp_path / ".palinode.db"))
+    monkeypatch.setattr(config.git, "auto_commit", False)
+    monkeypatch.setattr(config.auto_summary, "enabled", False)
+    return tmp_path
+
+
+@pytest.fixture()
+def client(memory_dir):
+    srv._rate_counters.clear()
+    with TestClient(app, raise_server_exceptions=False) as test_client:
+        yield test_client
+    srv._rate_counters.clear()
+
+
+def _write_lock(path: Path, **overrides) -> dict[str, object]:
+    metadata: dict[str, object] = {
+        "pid": os.getpid(),
+        "hostname": socket.gethostname(),
+        "created_at": time.time(),
+        "token": "prior-owner",
+    }
+    metadata.update(overrides)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(metadata) + "\n", encoding="utf-8")
+    return metadata
+
+
+def _hold_process_lock(memory_dir: str, ready, release) -> None:
+    with run_lock.consolidation_run_lock(memory_dir):
+        ready.set()
+        release.wait(timeout=10)
+
+
+def test_weekly_and_nightly_public_runners_share_one_lock(memory_dir):
+    path = run_lock.consolidation_lock_path()
+
+    with run_lock.consolidation_run_lock():
+        for run in (runner.run_consolidation, runner.run_nightly):
+            with pytest.raises(
+                run_lock.ConsolidationAlreadyRunning,
+                match="Consolidation is already running",
+            ):
+                run(dry_run=True)
+
+    assert not path.exists()
+
+
+def test_second_process_refuses_while_owner_is_alive(memory_dir):
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    release = context.Event()
+    process = context.Process(
+        target=_hold_process_lock,
+        args=(str(memory_dir), ready, release),
+    )
+    process.start()
+
+    try:
+        assert ready.wait(timeout=10), "child process did not acquire the lock"
+        with pytest.raises(
+            run_lock.ConsolidationAlreadyRunning,
+            match=f"pid={process.pid}",
+        ):
+            with run_lock.consolidation_run_lock(memory_dir):
+                pass
+    finally:
+        release.set()
+        process.join(timeout=10)
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=5)
+
+    assert process.exitcode == 0
+    assert not run_lock.consolidation_lock_path(memory_dir).exists()
+
+
+def test_successful_weekly_and_nightly_runs_release_lock(memory_dir):
+    path = run_lock.consolidation_lock_path()
+
+    assert runner.run_consolidation(dry_run=True)["status"] == "no notes found"
+    assert not path.exists()
+    assert runner.run_nightly(dry_run=True)["status"] == "no_new_notes"
+    assert not path.exists()
+
+
+def test_exception_path_releases_lock(memory_dir, monkeypatch):
+    path = run_lock.consolidation_lock_path()
+
+    def fail_run(**kwargs):
+        raise RuntimeError("injected consolidation failure")
+
+    monkeypatch.setattr(runner, "_run_consolidation_unlocked", fail_run)
+    with pytest.raises(RuntimeError, match="injected consolidation failure"):
+        runner.run_consolidation()
+
+    assert not path.exists()
+    with run_lock.consolidation_run_lock() as reacquired:
+        assert reacquired == path
+
+
+def test_dead_pid_lock_is_reclaimed_with_reason(memory_dir, monkeypatch, caplog):
+    path = run_lock.consolidation_lock_path()
+    old = _write_lock(path, pid=424242)
+    monkeypatch.setattr(run_lock, "_pid_is_alive", lambda pid: False)
+
+    with caplog.at_level(logging.WARNING, logger="palinode.consolidation"):
+        with run_lock.consolidation_run_lock():
+            current = json.loads(path.read_text(encoding="utf-8"))
+            assert current["token"] != old["token"]
+
+    assert not path.exists()
+    assert "Reclaimed stale consolidation lock" in caplog.text
+    assert "owner pid 424242 is no longer running" in caplog.text
+
+
+def test_ttl_stale_lock_is_reclaimed_with_reason(memory_dir, caplog):
+    path = run_lock.consolidation_lock_path()
+    _write_lock(
+        path,
+        hostname="another-host",
+        created_at=time.time() - run_lock.LOCK_TTL_SECONDS - 1,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="palinode.consolidation"):
+        with run_lock.consolidation_run_lock():
+            pass
+
+    assert not path.exists()
+    assert "exceeds TTL" in caplog.text
+
+
+def test_live_local_owner_is_not_reclaimed_only_for_age(memory_dir, monkeypatch):
+    path = run_lock.consolidation_lock_path()
+    _write_lock(
+        path,
+        created_at=time.time() - run_lock.LOCK_TTL_SECONDS - 1,
+    )
+    monkeypatch.setattr(run_lock, "_pid_is_alive", lambda pid: True)
+
+    with pytest.raises(run_lock.ConsolidationAlreadyRunning):
+        with run_lock.consolidation_run_lock():
+            pass
+
+
+def test_recent_malformed_lock_fails_closed(memory_dir):
+    path = run_lock.consolidation_lock_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not-json", encoding="utf-8")
+
+    with pytest.raises(
+        run_lock.ConsolidationAlreadyRunning,
+        match="owner metadata unavailable",
+    ):
+        with run_lock.consolidation_run_lock():
+            pass
+
+
+def test_failed_lock_metadata_write_does_not_leave_wedge(memory_dir, monkeypatch):
+    path = run_lock.consolidation_lock_path()
+
+    def fail_write(fd, data):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(run_lock.os, "write", fail_write)
+    with pytest.raises(OSError, match="disk full"):
+        with run_lock.consolidation_run_lock():
+            pass
+
+    assert not path.exists()
+
+
+def test_release_never_deletes_a_replacement_owner(memory_dir, caplog):
+    path = run_lock.consolidation_lock_path()
+
+    with caplog.at_level(logging.WARNING, logger="palinode.consolidation"):
+        with run_lock.consolidation_run_lock():
+            _write_lock(path, token="replacement-owner")
+
+    assert path.exists()
+    assert "owned by another run" in caplog.text
+    path.unlink()
+
+
+@pytest.mark.parametrize("nightly", [False, True])
+def test_api_returns_clear_409_while_store_is_locked(client, nightly):
+    with run_lock.consolidation_run_lock():
+        response = client.post(
+            "/consolidate",
+            json={"dry_run": True, "nightly": nightly},
+        )
+
+    assert response.status_code == 409
+    assert "Consolidation is already running" in response.json()["detail"]
+
+
+def test_cli_relays_busy_detail_and_exits_nonzero():
+    consolidate_cli = importlib.import_module("palinode.cli.consolidate")
+    detail = "Consolidation is already running (pid=123)."
+    request = httpx.Request("POST", "http://palinode.test/consolidate")
+    response = httpx.Response(409, json={"detail": detail}, request=request)
+    error = httpx.HTTPStatusError(
+        "409 Conflict",
+        request=request,
+        response=response,
+    )
+
+    with patch.object(consolidate_cli.api_client, "consolidate", side_effect=error):
+        result = CliRunner().invoke(consolidate_cli.consolidate, ["--dry-run"])
+
+    assert result.exit_code == 1
+    assert detail in result.output
+
+
+@pytest.mark.asyncio
+async def test_mcp_relays_busy_detail(monkeypatch):
+    detail = "Consolidation is already running (pid=123)."
+
+    class BusyResponse:
+        status_code = 409
+        text = json.dumps({"detail": detail})
+
+    async def busy_post(*args, **kwargs):
+        return BusyResponse()
+
+    monkeypatch.setattr(mcp, "_post", busy_post)
+    result = await _dispatch_tool("palinode_consolidate", {"dry_run": True})
+
+    assert detail in result[0].text
+
+
+def test_cron_logs_busy_detail_and_exits_nonzero(memory_dir, monkeypatch, caplog):
+    def busy_run(**kwargs):
+        raise run_lock.ConsolidationAlreadyRunning("Consolidation is already running")
+
+    monkeypatch.setattr(config.consolidation, "enabled", True)
+    monkeypatch.setattr(cron, "run_consolidation", busy_run)
+    monkeypatch.setattr(sys, "argv", ["palinode.consolidation.cron"])
+
+    with caplog.at_level(logging.ERROR, logger="palinode.consolidation.cron"):
+        with pytest.raises(SystemExit) as raised:
+            cron.main()
+
+    assert raised.value.code == 1
+    assert "Consolidation is already running" in caplog.text
+
+
+def test_lock_uses_gitignored_operational_directory(memory_dir):
+    path = run_lock.consolidation_lock_path()
+    repository_root = Path(__file__).resolve().parents[1]
+
+    assert path.relative_to(memory_dir).as_posix() == ".palinode/consolidation.lock"
+    assert ".palinode/" in (repository_root / ".gitignore").read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #84

## Why

Weekly and nightly consolidation both read, mutate, and commit the same memory store. Because every surface ultimately reaches one of the two public runner functions, guarding those boundaries prevents API, CLI/MCP, and scheduled runs from proposing or applying operations concurrently.

## What changed

- acquire `.palinode/consolidation.lock` atomically under the configured memory directory for both public runners
- record PID, hostname, creation time, and an owner token without storing memory content
- reject a live second run immediately with a typed, actionable message
- reclaim a dead local PID or a TTL-stale unverifiable/remote lock and log the reason
- never let age override a verifiably live local PID, and never let one run release another run's token
- map the busy signal to API 409, a nonzero CLI/cron exit, and the existing MCP error relay
- clean up ownership after success, exceptions, and lock-metadata write failures
- document the user-visible behavior in `Unreleased / Fixed`

## Validation

- focused consolidation/surface coverage: `54 passed`
- full suite: `2819 passed, 10 skipped, 5 xfailed`
- Ruff: all checks passed
- Bandit: 0 medium/high findings
- `git diff --check`: passed

The regression suite uses a real temporary store and includes a spawned second process, stale dead-PID and TTL recovery, weekly/nightly shared ownership, API/CLI/MCP/cron behavior, success/exception release, and replacement-owner protection.

## AI disclosure

I used OpenAI Codex to help inspect the entry points, implement the lock, and run the validation. I reviewed the final diff and test results before submission.
