### PR TITLE
fix: preserve read bodies with frontmatter hyphens

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- **`palinode read --meta --format text` now preserves bodies when a frontmatter
+  value contains `---`.** The CLI uses the canonical fence-line-aware splitter
+  instead of treating any three hyphens inside the YAML block as its closing fence.
+
 - **Concurrent consolidation runs now refuse instead of racing over store
   mutations and git commits.** Weekly and nightly runs share a store-local,
   stale-recoverable lock across API, CLI/MCP, and cron entry points.

--- a/palinode/cli/read.py
+++ b/palinode/cli/read.py
@@ -16,6 +16,7 @@ import click
 
 from palinode.cli._api import HTTPStatusError, api_client
 from palinode.cli._format import OutputFormat, get_default_format
+from palinode.core.parser import split_frontmatter
 
 
 @click.command()
@@ -86,16 +87,6 @@ def _format_with_meta(result: dict) -> str:
     # When meta=True, the API returns the full file content (frontmatter +
     # body).  Strip the leading frontmatter block for cleaner CLI output.
     content = result.get("content", "")
-    body = _strip_frontmatter(content)
+    _, body = split_frontmatter(content)
     lines.append(body)
     return "\n".join(lines)
-
-
-def _strip_frontmatter(content: str) -> str:
-    """If `content` starts with `---`, drop the frontmatter block."""
-    if not content.startswith("---"):
-        return content
-    parts = content.split("---", 2)
-    if len(parts) < 3:
-        return content
-    return parts[2].lstrip("\n")

--- a/tests/test_cli_read.py
+++ b/tests/test_cli_read.py
@@ -1,0 +1,30 @@
+"""Regression coverage for the ``palinode read`` presenter."""
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from palinode.cli.read import api_client, read
+
+
+def test_read_meta_keeps_body_when_frontmatter_value_contains_fence(monkeypatch):
+    content = (
+        "---\n"
+        'title: "alpha---beta"\n'
+        "category: insights\n"
+        "---\n"
+        "The body remains intact."
+    )
+    payload = {
+        "file": "insights/fenced-title.md",
+        "content": content,
+        "frontmatter": {"title": "alpha---beta", "category": "insights"},
+    }
+    monkeypatch.setattr(api_client, "read", lambda file_path, meta: payload)
+
+    result = CliRunner().invoke(
+        read, ["insights/fenced-title.md", "--meta", "--format", "text"]
+    )
+
+    assert result.exit_code == 0, result.output
+    content_section = result.output.split("── Content ──\n", 1)[1]
+    assert content_section == "The body remains intact.\n"


### PR DESCRIPTION
## Why

The read presenter split on any occurrence of three hyphens, so a sequence inside a frontmatter value was mistaken for the closing fence and YAML fragments leaked into the displayed body.

## What changed

- use the canonical fence-line-aware split_frontmatter helper
- remove the hand-rolled CLI splitter
- add Click-level regression coverage for read --meta --format text
- document the fix under Unreleased

Fixes #100.

## Validation

- regression test failed before the implementation and passes after it
- 53 related read/parser tests passed
- full sandbox suite: 2823 passed, 10 skipped, 5 xfailed; the four socket/home-path tests blocked by sandbox policy passed when rerun with those capabilities
- ruff check palinode/ tests/ scripts/
- bandit -r palinode/ -ll
- git diff --check