### PR TITLE
docs: align parity guide with executable guards

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -142,45 +142,32 @@ Promoting each (registry `Operation` + canonical params + removing its backlog e
 
 ## httpx monopoly — the bypass linter
 
-CLI commands and the plugin go through one HTTP layer each: `palinode/cli/_api.py` and `palinode/mcp.py`. Direct `httpx` calls from elsewhere skip rate limiting, audit logging, source headers, and any future API-side fixes. The pre-commit linter at `scripts/check-httpx-monopoly.sh` greps for offenders and fails CI.
+Python CLI commands that call the Palinode API go through
+`palinode/cli/_api.py`. Direct `httpx` calls from another CLI module skip rate
+limiting, audit logging, source headers, and any future API-side fixes.
 
-Today's bypass-vector files (cleanup tracked in #168 and #170 lower-tier):
+`scripts/check-httpx-monopoly.sh` enforces that boundary. It scans
+`palinode/cli/*.py`, allows the canonical `_api.py` client, and fails on raw
+`httpx` use anywhere else in that scope. Its `GRANDFATHERED` list is empty, so
+there are no accepted bypasses to inventory here.
 
-- `palinode/cli/read.py` — reads disk directly, never calls API
-- `palinode/cli/list.py` — uses raw `httpx.get`
-- `palinode/cli/lint.py` — falls back to direct module import on connection failure
-- `palinode/cli/session_end.py` — bypasses `_api.py`
+CI runs both the guard and its regression suite in the `httpx-monopoly` job:
+`bash scripts/check-httpx-monopoly.sh` followed by
+`bash tests/test_check_httpx_monopoly.sh`. The executable guard is the current
+inventory; this document does not duplicate temporary exceptions.
 
-After cleanup, the linter prevents recurrence.
+## Known drift
 
-## Known drift — at-a-glance
+`Operation.known_drift` in `palinode/core/parity.py` is the only drift
+inventory. Do not copy its entries into a hand-maintained table here: that
+second list cannot participate in either parity guard and will drift from the
+registry again.
 
-The registry is the precise list. This summary tracks roll-up status:
-
-| Issue | Operation | Surfaces | Param           | Status |
-|-------|-----------|----------|-----------------|--------|
-| #159  | save      | CLI/MCP/API/Plugin | project | open |
-| #161  | search    | MCP      | category enum (singular→plural) | **fixed in this commit** |
-| #162  | prompt    | MCP      | duplicate `enum` keys           | **fixed in this commit** |
-| #163  | search    | CLI      | since_days, types, threshold, date_after, date_before, include_daily | open |
-| #163  | search    | MCP      | since_days, types, threshold | open |
-| #163  | search    | Plugin   | threshold, since_days, types, date_after, date_before, include_daily | open |
-| #164  | rollback  | MCP      | file_path (canonical name)      | open |
-| #164  | rollback  | CLI      | dry_run (--execute negation)    | open |
-| #164  | blame     | MCP      | file_path (canonical name)      | open |
-| #165  | trigger.create | CLI | cooldown_hours, trigger_id     | open |
-| #165  | trigger.create | MCP | threshold, cooldown_hours      | open |
-| #166  | save      | CLI/MCP  | metadata, confidence            | open |
-| #166  | save      | CLI      | slug, core                      | open |
-| #166  | save      | MCP/API  | title                           | open |
-| #166  | save      | Plugin   | metadata, confidence, project, title, source | open |
-| #168  | read      | MCP      | meta (frontmatter passthrough)  | open |
-| #169  | consolidate | MCP    | dry_run, nightly                | open |
-
-When an issue closes:
-1. Remove its entry from `Operation.known_drift` in `palinode/core/parity.py`.
-2. Update the row in this table.
-3. Run the parity test — should go from xfail to pass for the affected case.
+The Python suite validates the registry's Python-surface entries and rejects
+dangling drift keys. `plugin/test/parity.test.ts` reads the same registry dump
+and applies the same rule to plugin parameters. When a drift issue is fixed,
+remove its `known_drift` entry and run both suites; each guard deliberately
+fails if a now-present parameter still carries a stale exception.
 
 ## See also
 

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -12,9 +12,12 @@ reported as ``xfail`` with a ``reason="drift tracked in #N"`` — the test
 ``known_drift`` entry must be removed (or the test will fail because the
 parameter now appears unexpectedly).
 
-Plugin parity is documented in ``docs/PARITY.md`` but not asserted in v0
-(Python cannot easily introspect TypeBox schemas in ``plugin/index.ts``).
-A plugin-side TypeScript test is a follow-up.
+The parametrized checks in this Python module intentionally skip the plugin:
+Python cannot introspect the TypeBox schemas in ``plugin/index.ts``.  Plugin
+parameter parity is enforced separately by ``plugin/test/parity.test.ts``,
+which reads a generated JSON dump of the same Python registry.  The enum test
+near the end of this module additionally guards the plugin's canonical literal
+sets directly from source.
 
 Run: ``pytest tests/test_surface_parity.py -v``
 """
@@ -291,7 +294,7 @@ def _surface_param_names(op: Operation, surface: Surface) -> set[str]:
         method, path = op.api_endpoint
         return _api_param_names(method, path)
     if surface == "plugin":
-        # Plugin parity is documented in PARITY.md, not asserted in v0.
+        # TypeBox parameter introspection belongs to plugin/test/parity.test.ts.
         return set()
     raise AssertionError(f"unknown surface {surface!r}")
 
@@ -329,7 +332,8 @@ def _surface_param_enum(
 def _flatten_cases() -> list[tuple[Operation, Surface, CanonicalParam]]:
     cases: list[tuple[Operation, Surface, CanonicalParam]] = []
     for op in REGISTRY:
-        # v0: skip plugin parity entirely
+        # Python covers its introspectable surfaces; the TypeScript suite builds
+        # the corresponding plugin cases from the same registry dump.
         for surface in sorted(required_surfaces(op) - {"plugin"}):
             for cp in op.canonical_params:
                 cases.append((op, surface, cp))  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- remove the stale hand-maintained drift table in favor of `Operation.known_drift`
- document the current CLI-only httpx monopoly guard and its empty exception list
- clarify how the Python and TypeScript suites split plugin parity coverage

Closes #109.

## Validation

- `.venv/bin/pytest -q` — 2964 passed, 8 skipped, 5 xfailed
- `.venv/bin/pytest -q tests/test_surface_parity.py tests/test_parity_is_dependency_free.py` — 222 passed, 1 xfailed
- `cd plugin && npm test` — 62 passed
- `bash scripts/check-httpx-monopoly.sh && bash tests/test_check_httpx_monopoly.sh` — 5 passed
- Ruff and Bandit passed

## Changelog

`skip-changelog`: documentation and test commentary only; no shipped behavior changes.

## AI assistance

I used OpenAI Codex to inspect the live registry, guards, and CI wiring; edit the documentation; and run the validation listed above. I reviewed the final diff and verified every updated claim against the current source.