### PR TITLE
docs: explain quote_hash frontmatter format

### DIFF
--- a/docs/HOW-MEMORY-WORKS.md
+++ b/docs/HOW-MEMORY-WORKS.md
@@ -381,7 +381,24 @@ Palinode memory files optionally carry three fields from the [IETF Knowledge Uni
 
 **Auto-population:** Set `ku_compat: enabled: true` in `palinode.config.yaml` to automatically write `ku_version` and `lifecycle` on every save.
 
-## 7d. Dependency Frontmatter (ProjectSnapshot)
+## 7d. Source Citation Anchors (`quote_hash`)
+
+A memory can cite an exact passage from another file with a `sources:` frontmatter entry:
+
+```yaml
+sources:
+  - ref: research/some-paper.md
+    quote: "The exact cited passage."
+    quote_hash: "sha256:<64-hex-digest>"
+```
+
+`quote_hash` uses the explicit `<algorithm>:<hex>` format. New hashes use `sha256`; `md5` is also understood for older anchors. For compatibility, Palinode resolves a bare 32-character hexadecimal digest as MD5 and a bare 64-character digest as SHA-256, but hand-written anchors should include the algorithm prefix.
+
+The digest is computed from the normalized quote: smart punctuation is folded to its ASCII equivalent, each run of whitespace is collapsed to one space, and leading or trailing whitespace is removed. These smart-punctuation and spacing differences therefore do not invalidate an otherwise identical quote.
+
+The `quote_hash` field may be omitted when saving through Palinode. Palinode computes and stores the default `sha256:` hash automatically. If a hash is supplied, it must match the normalized `quote`; a mismatched value is rejected as an inconsistent anchor. This hash checks citation integrity and is not a cryptographic signature or attestation.
+
+## 7e. Dependency Frontmatter (ProjectSnapshot)
 
 ProjectSnapshot memories can carry optional dependency fields that model milestone and task sequencing:
 


### PR DESCRIPTION
## Summary

- add a copyable `sources:` frontmatter example for hand-written citation anchors
- document the algorithm-prefixed `quote_hash` format and legacy bare-digest compatibility
- explain quote normalization, automatic SHA-256 generation on save, and integrity-only scope

## Why

The behavior is implemented and tested in `palinode/core/quote_verify.py`, but users who edit memory frontmatter directly had no format documentation. This puts the contract alongside the other supported frontmatter fields.

## Validation

- `PALINODE_DIR=<temp> python -m pytest -q tests/test_quote_hash_prefixing.py tests/test_source_capture_g1.py` — 63 passed
- `python -m ruff check palinode/ tests/ scripts/` — passed
- `python -m bandit -r palinode/ -ll` — no medium/high issues
- `git diff --check` — passed

Docs-only change; skip changelog.

Closes #67
