### PR TITLE
docs: explain legacy quote hash upgrades

### DIFF
--- a/docs/HOW-MEMORY-WORKS.md
+++ b/docs/HOW-MEMORY-WORKS.md
@@ -398,6 +398,8 @@ The digest is computed from the normalized quote: smart punctuation is folded to
 
 The `quote_hash` field may be omitted when saving through Palinode. Palinode computes and stores the default `sha256:` hash automatically. If a hash is supplied, it must match the normalized `quote`; a mismatched value is rejected as an inconsistent anchor. This hash checks citation integrity and is not a cryptographic signature or attestation.
 
+On save, a valid legacy `md5:` or bare 32-character MD5 anchor is validated with MD5 and then stored as a `sha256:` anchor, upgrading it in place.
+
 ## 7e. Dependency Frontmatter (ProjectSnapshot)
 
 ProjectSnapshot memories can carry optional dependency fields that model milestone and task sequencing:


### PR DESCRIPTION
## Summary

Document the final save-time behavior for valid legacy citation anchors: Palinode validates an `md5:` or bare 32-character MD5 hash with MD5, then stores the anchor in the current `sha256:` form.

This is the one-sentence follow-up identified while reviewing #111. It does not alter the contributor's merged documentation or any runtime behavior.

## Validation

- `git diff --check`
- `uv run pytest -q tests/test_quote_hash_prefixing.py tests/test_source_capture_g1.py` — 63 passed

## Changelog

`skip-changelog`: documentation clarification only.
