### PR TITLE
fix(review): honor TTY-aware output and exit non-zero on API failure (closes #114)

### DIFF
--- a/palinode/cli/review.py
+++ b/palinode/cli/review.py
@@ -3,14 +3,14 @@ import click
 from rich.console import Console
 
 from palinode.cli._api import HTTPStatusError, RequestError, api_client
-from palinode.cli._format import emit_json
+from palinode.cli._format import OutputFormat, emit_json, get_default_format
 
 console = Console()
 
 
 @click.command()
 @click.argument("project", required=False)
-@click.option("--format", "fmt", type=click.Choice(["json", "text"]), default="text", help="Output format")
+@click.option("--format", "fmt", type=click.Choice(["json", "text"]), help="Output format")
 def review(project, fmt):
     """Advisory project-memory review.
 
@@ -22,13 +22,14 @@ def review(project, fmt):
         data = api_client.review(project)
     except HTTPStatusError as e:
         console.print(f"[red]Error: API returned {e.response.status_code}[/red]")
-        return
+        raise SystemExit(1)
     except RequestError:
         # Fallback to local in-process review if the API is down.
         from palinode.core.review import run_review
         data = run_review(project=project)
 
-    if fmt == "json":
+    output_fmt = OutputFormat(fmt) if fmt else get_default_format()
+    if output_fmt == OutputFormat.JSON:
         emit_json(data)
         return
 

--- a/tests/test_review_cli.py
+++ b/tests/test_review_cli.py
@@ -1,4 +1,4 @@
-"""CLI-surface tests for ``palinode review`` (issue #114).
+"""CLI-surface tests for ``palinode review`` (https://github.com/phasespace-labs/palinode/issues/114).
 
 ``review`` must follow the two CLI conventions the rest of the commands honour:
 

--- a/tests/test_review_cli.py
+++ b/tests/test_review_cli.py
@@ -1,0 +1,85 @@
+"""CLI-surface tests for ``palinode review`` (issue #114).
+
+``review`` must follow the two CLI conventions the rest of the commands honour:
+
+* **TTY-aware output.** Human-readable when interactive, JSON when piped —
+  ``palinode/cli/_format.py`` centralises this in ``get_default_format()``.
+  ``CliRunner`` gives a non-TTY stdout, so the piped default must be JSON.
+* **Non-zero exit on API failure.** An ``HTTPStatusError`` from the API is a
+  failure; a script running ``palinode review`` in CI must be able to tell a
+  clean review from a 500.
+
+The ``RequestError`` path is a deliberate local-in-process fallback (the API
+being down is not an error), so it is intentionally not exercised here.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from unittest.mock import patch
+
+from palinode.cli import main as cli_main
+
+
+SAMPLE_REVIEW = {
+    "project": "project/alpha",
+    "summary": {"scope_file_count": 3, "finding_count": 1, "proposed_op_count": 1},
+    "findings": {"stale": [{"file": "insights/old.md", "days_old": 200}]},
+    "proposed_ops": [{"op": "PROPOSE_ARCHIVE", "file": "insights/old.md", "reason": "stale"}],
+    "hints": [],
+}
+
+
+def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    """Build an ``HTTPStatusError`` whose ``.response.status_code`` is set,
+    matching what ``review`` reads on the failure path."""
+    request = httpx.Request("POST", "http://testserver/review")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(
+        f"{status_code} Server Error", request=request, response=response
+    )
+
+
+def test_review_piped_default_is_json():
+    """With no --format and a non-TTY stdout, output is machine-readable JSON."""
+    with patch("palinode.cli._api.api_client.review", return_value=SAMPLE_REVIEW):
+        result = CliRunner().invoke(cli_main, ["review", "alpha"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == SAMPLE_REVIEW
+
+
+def test_review_explicit_json_matches_default():
+    """--format json is identical to the piped default."""
+    with patch("palinode.cli._api.api_client.review", return_value=SAMPLE_REVIEW):
+        result = CliRunner().invoke(cli_main, ["review", "alpha", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == SAMPLE_REVIEW
+
+
+def test_review_explicit_text_is_not_json():
+    """--format text renders the human report, which is not valid JSON."""
+    with patch("palinode.cli._api.api_client.review", return_value=SAMPLE_REVIEW):
+        result = CliRunner().invoke(cli_main, ["review", "alpha", "--format", "text"])
+
+    assert result.exit_code == 0, result.output
+    assert "Palinode Memory Review" in result.output
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(result.output)
+
+
+def test_review_api_failure_exits_nonzero():
+    """An HTTPStatusError from the API must produce a non-zero exit code."""
+    with patch(
+        "palinode.cli._api.api_client.review",
+        side_effect=_http_status_error(500),
+    ):
+        result = CliRunner().invoke(cli_main, ["review", "alpha"])
+
+    assert result.exit_code != 0
+    assert "500" in result.output


### PR DESCRIPTION
Closes #114

`palinode review` ignored two CLI conventions the rest of the commands follow. Both are one-line fixes in `palinode/cli/review.py`.

### 1. TTY-aware output
`--format` was hardcoded to `default="text"`, so `palinode review | jq` got a Rich-rendered report instead of JSON. That output goes through `rich.Console`, which hard-wraps at the 80-column non-TTY fallback and consumes `[...]` as style markup (`emit_json`'s docstring in `_format.py` explains the three ways this corrupts machine-readable output).

The default now comes from `get_default_format()` — the same helper 21 other CLI modules use (`status.py`, `archive.py`, …): **text when interactive, JSON when piped**. An explicit `--format` still wins.

### 2. Non-zero exit on API failure
The `HTTPStatusError` path printed an error and `return`ed, so the process reported **success** — a CI script running `palinode review` could not tell a clean review from a 500. It now `raise SystemExit(1)`, matching the other error paths (`archive.py`, `migrate.py`).

The `RequestError` path below it is a deliberate local-in-process fallback (the API being down is not an error), so it's left untouched, as the issue requests.

## Tests

New `tests/test_review_cli.py` (CliRunner gives a non-TTY stdout by default):

- piped default parses as JSON
- explicit `--format json` matches that default
- explicit `--format text` renders the human report (asserts it is *not* JSON)
- an `HTTPStatusError` from the API → non-zero exit + status code printed

`ruff check` passes on both files under the repo's configured ruleset. Related existing suites stay green: `test_review_cli.py` + `test_cli_json_output.py` + `test_review.py` → **19 passed**.

## Sister issue

This is the `review.py` half; #113 covers the same two conventions in `lint.py` plus a rendering bug there. Split by file on purpose — this PR touches nothing #113 touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)