### PR TITLE
docs: credit Sukesh Kumar

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,6 +13,7 @@ Contributions welcome via pull request. Names appear here once a PR is merged.
 - [Aditya Datta](https://github.com/adity982)
 - [Deepak Nayak](https://github.com/deepunyk)
 - [Floze](https://github.com/floze-the-genius)
+- [Sukesh Kumar](https://github.com/SkxOverKill)
 
 ## Acknowledgements
 


### PR DESCRIPTION
Adds Sukesh Kumar to `AUTHORS.md` after his first contribution merged in #115.

Validation:
- `git diff --check`
- `uv run pytest -q tests/test_no_issue_refs_user_surface.py` — 10 passed

Changelog: skip — contributor credit only.