### PR TITLE
feat(lint): report relative date expressions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Added
 
+- **Relative-date lint findings** flag the finite set of unanchored time
+  expressions that become misleading as living memories age, while exempting
+  dated `daily/` notes and reporting each expression with its source line.
+
 ### Changed
 
 ### Fixed

--- a/palinode/cli/lint.py
+++ b/palinode/cli/lint.py
@@ -113,6 +113,20 @@ def lint(fmt, deep_contradictions, max_llm_calls, similarity_threshold):
 
     console.print("")
 
+    relative_dates = data.get("relative_dates", [])
+    if relative_dates:
+        match_count = sum(len(item.get("matches", [])) for item in relative_dates)
+        console.print(f"[bold yellow]Relative Dates ({match_count})[/bold yellow]")
+        for item in relative_dates:
+            for match in item.get("matches", []):
+                console.print(
+                    f"  - {item['file']}:{match['line']}: {match['expression']}"
+                )
+    else:
+        console.print("[green]✓ No relative dates[/green]")
+
+    console.print("")
+
     # source-citation anchor integrity (drifted / missing / tampered).
     source_issues = data.get("source_anchor_issues", [])
     if source_issues:

--- a/palinode/core/lint.py
+++ b/palinode/core/lint.py
@@ -17,6 +17,21 @@ from palinode.core import parser
 # deliberately links every frontmatter entity that has no inline body link.
 _AUTO_FOOTER_MARKER = "<!-- palinode-auto-footer -->"
 
+_RELATIVE_DATE_NUMBER = (
+    r"(?:\d+|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)"
+)
+_RELATIVE_DATE_RE = re.compile(
+    rf"(?<!\w)(?:"
+    rf"{_RELATIVE_DATE_NUMBER} (?:days|weeks|months|years) ago|"
+    r"last (?:week|month|year)|"
+    r"next (?:week|month|year)|"
+    r"this (?:week|month)|"
+    r"right now|these days|"
+    r"yesterday|today|tomorrow|recently|lately|currently"
+    r")(?!\w)",
+    re.IGNORECASE,
+)
+
 def _alias_key(name: str) -> str:
     """Separator-and-case-insensitive form of an entity ref's name part.
 
@@ -355,6 +370,17 @@ def check_wiki_drift(
     return warnings
 
 
+def check_relative_dates(body: str) -> list[dict[str, str]]:
+    """Return relative time expressions whose meaning will drift over time."""
+    findings: list[dict[str, str]] = []
+    for line_number, line in enumerate(body.splitlines(), start=1):
+        findings.extend(
+            {"line": str(line_number), "expression": match.group(0)}
+            for match in _RELATIVE_DATE_RE.finditer(line)
+        )
+    return findings
+
+
 def run_lint_pass() -> dict[str, Any]:
     """Scan PALINODE_DIR for memory health issues.
     
@@ -375,6 +401,7 @@ def run_lint_pass() -> dict[str, Any]:
     missing_descriptions: list[str] = []
     missing_priority: list[str] = []
     wiki_drift: list[dict[str, Any]] = []
+    relative_dates: list[dict[str, Any]] = []
     source_anchor_issues: list[dict[str, Any]] = []
     claim_anchor_issues: list[dict[str, Any]] = []
     # (ADR-018): an `epistemic: open_question` that has gone unresolved for a
@@ -532,6 +559,10 @@ def run_lint_pass() -> dict[str, Any]:
             if drift_warnings:
                 wiki_drift.append({"file": path, "warnings": drift_warnings})
 
+            relative_date_matches = check_relative_dates(body)
+            if relative_date_matches:
+                relative_dates.append({"file": path, "matches": relative_date_matches})
+
         # 8. Source-citation anchors — verify each ``sources:`` anchor's
         # integrity hash and that the cited quote still appears in its source.
         # Clean no-op for files with no anchors (verify returns []). Only
@@ -632,6 +663,7 @@ def run_lint_pass() -> dict[str, Any]:
         "missing_descriptions": missing_descriptions,
         "missing_priority": missing_priority,
         "wiki_drift": wiki_drift,
+        "relative_dates": relative_dates,
         "source_anchor_issues": source_anchor_issues,
         "claim_anchor_issues": claim_anchor_issues,
         "stale_open_questions": stale_open_questions,

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,6 +1,131 @@
 from datetime import datetime, timedelta, timezone
-from palinode.core.lint import run_lint_pass
+import pytest
+
+from palinode.core.lint import check_relative_dates, run_lint_pass
 from palinode.core.config import config
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        "yesterday",
+        "today",
+        "tomorrow",
+        "last week",
+        "last month",
+        "last year",
+        "next week",
+        "next month",
+        "next year",
+        "this week",
+        "this month",
+        "recently",
+        "lately",
+        "currently",
+        "right now",
+        "these days",
+    ]
+    + [
+        f"{number} {unit} ago"
+        for number in [
+            "3",
+            "one",
+            "two",
+            "three",
+            "four",
+            "five",
+            "six",
+            "seven",
+            "eight",
+            "nine",
+            "ten",
+            "eleven",
+            "twelve",
+        ]
+        for unit in ["days", "weeks", "months", "years"]
+    ],
+)
+def test_check_relative_dates_matches_specified_expressions(expression):
+    body = f"First line.\nWe wrote {expression} in a memory."
+
+    assert check_relative_dates(body) == [{"line": "2", "expression": expression}]
+
+
+def test_check_relative_dates_is_case_insensitive_and_flags_quoted_text():
+    body = 'She said, "YESTERDAY we decided it."\nRIGHT NOW it still applies.'
+
+    assert check_relative_dates(body) == [
+        {"line": "1", "expression": "YESTERDAY"},
+        {"line": "2", "expression": "RIGHT NOW"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "The decision was recorded on 2026-08-03.",
+        "The launch month is August.",
+        "TodaysStatus is a legacy identifier.",
+    ],
+)
+def test_check_relative_dates_ignores_out_of_scope_text(body):
+    assert check_relative_dates(body) == []
+
+
+def test_lint_relative_dates_exempts_daily_logs(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "memory_dir", str(tmp_path))
+    daily_dir = tmp_path / "daily"
+    insights_dir = tmp_path / "insights"
+    daily_dir.mkdir()
+    insights_dir.mkdir()
+
+    (daily_dir / "2026-08-11.md").write_text(
+        "Yesterday we shipped the release.\n", encoding="utf-8"
+    )
+    (insights_dir / "drifting.md").write_text(
+        "---\nid: insights-drifting\ncategory: insights\ntype: Insight\n---\n"
+        "Stable first line.\nTomorrow we will revisit it.\n",
+        encoding="utf-8",
+    )
+
+    result = run_lint_pass()
+
+    assert result["relative_dates"] == [
+        {
+            "file": "insights/drifting.md",
+            "matches": [{"line": "2", "expression": "Tomorrow"}],
+        }
+    ]
+
+
+def test_lint_cli_renders_relative_dates(monkeypatch):
+    import importlib
+
+    from click.testing import CliRunner
+
+    lint_module = importlib.import_module("palinode.cli.lint")
+
+    data = {
+        "missing_fields": [],
+        "orphaned_files": [],
+        "stale_files": [],
+        "contradictions": [],
+        "missing_entities": [],
+        "missing_descriptions": [],
+        "relative_dates": [
+            {
+                "file": "decisions/launch.md",
+                "matches": [{"line": "4", "expression": "next month"}],
+            }
+        ],
+    }
+    monkeypatch.setattr(lint_module.api_client, "lint", lambda: data)
+
+    result = CliRunner().invoke(lint_module.lint, ["--format", "text"])
+
+    assert result.exit_code == 0
+    assert "Relative Dates (1)" in result.output
+    assert "decisions/launch.md:4: next month" in result.output
 
 def test_lint_pass(tmp_path, monkeypatch):
     """Test the lint logic with simulated memory files."""


### PR DESCRIPTION
## Why

Relative dates in living memory files lose their anchor as the files age or are consolidated. This makes the drift visible without guessing an absolute replacement date.

## What changed

- add `check_relative_dates(body)` for the exact finite expression list in #83;
- report every match with its 1-based body line and original matched expression;
- skip dated `daily/` notes in `run_lint_pass()`;
- render findings in the text CLI as well as the existing JSON result;
- cover every fixed phrase, all `one` through `twelve` × four units, arbitrary digits, case-insensitivity, quoted text, required negatives, daily exemption, and CLI rendering;
- add the required Unreleased changelog entry.

## Validation

- `82 passed` in `tests/test_lint.py`
- full suite: `3040 passed, 10 skipped, 5 xfailed`
- `ruff check palinode/ tests/ scripts/`
- `bandit -r palinode/ -ll` (0 medium/high findings)
- `git diff --check`

Closes #83.
