### PR TITLE
fix(parity): annotate MCP inventory aliases

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- **Parity inventory no longer counts the deprecated `palinode_timeline` alias as a separate capability (#99).** The alias now annotates the canonical `palinode_history` backlog entry while remaining live and deprecated at runtime.
+
 ### Removed
 
 ### Security

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -124,7 +124,7 @@ The param checks above walk `REGISTRY` and verify each surface (registry→surfa
 
 1. **`REGISTRY`** — a parity-bound memory operation (mapped via its `mcp_tool` / `api_endpoint` / `cli_command`).
 2. **`INVENTORY_INFRA`** (`palinode/core/parity.py`) — framework/admin/observability surface that is *not* a memory operation: Swagger/Redoc/OpenAPI, the HTML inspector under `/ui`, liveness probes, and the DB-maintenance + importer endpoints (the surface-identifier form of `ADMIN_EXEMPT_OPERATIONS`).
-3. **`INVENTORY_BACKLOG`** (`palinode/core/parity.py`) — a memory-semantic operation that already ships on the surface but has **not yet** been promoted into `REGISTRY` with canonical params. Each entry maps to its tracking issue (the ADR-010 implementation backlog, mostly #170). These are acknowledged, not silently ignored.
+3. **`INVENTORY_BACKLOG`** (`palinode/core/parity.py`) — a memory-semantic operation that already ships on the surface but has **not yet** been promoted into `REGISTRY` with canonical params. Each entry maps to its tracking issue (the ADR-010 implementation backlog, mostly #170), and alternate names annotate the canonical entry instead of counting as additional capabilities. These are acknowledged, not silently ignored.
 
 A live capability in none of the three buckets **fails the guard** — that is an operation that skipped the contract. Stale buckets also fail (`test_inventory_accounting_is_not_stale`): an entry whose capability was renamed or removed must be cleaned up, mirroring the `known_drift` hygiene rule. `test_inventory_buckets_are_disjoint` keeps each capability classified exactly once.
 
@@ -136,7 +136,7 @@ Identifier form per surface: MCP = tool name (`palinode_search`); API = `METHOD 
 
 These memory-semantic operations ship on all of MCP/API/CLI today but are not yet promoted into `REGISTRY` with canonical params. They are tracked under #170 (admin/framework surface is in `INVENTORY_INFRA`, not here):
 
-`dedup_suggest`, `diff`, `entities`, `history`, `ingest`/`ingest-url`, `lint`, `orphan_repair`, `prompt` (list/show/activate), `push`, `session_end`, `timeline`, and the trigger `list`/`remove` + `check-triggers` + `search-associative` API endpoints. `depends/_unblocked` is tracked under #97.
+`dedup_suggest`, `diff`, `entities`, `history` (including the deprecated MCP `palinode_timeline` alias), `ingest`/`ingest-url`, `lint`, `orphan_repair`, `prompt` (list/show/activate), `push`, `session_end`, `timeline`, and the trigger `list`/`remove` + `check-triggers` + `search-associative` API endpoints. `depends/_unblocked` is tracked under #97.
 
 Promoting each (registry `Operation` + canonical params + removing its backlog entry) is the per-op work the issue tracks; this contract makes the gap explicit and prevents *new* unregistered ops from slipping in alongside them.
 

--- a/palinode/core/parity.py
+++ b/palinode/core/parity.py
@@ -83,6 +83,14 @@ class Operation:
     known_drift: dict[tuple[Surface, str], int] = field(default_factory=dict)
 
 
+@dataclass(frozen=True)
+class InventoryBacklogEntry:
+    """One unregistered capability, including alternate surface names."""
+
+    issue: int
+    aliases: tuple[str, ...] = ()
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Admin carve-out
 # ─────────────────────────────────────────────────────────────────────────────
@@ -646,19 +654,18 @@ INVENTORY_INFRA: dict[Surface, frozenset[str]] = {
 #: neither registered, infra, nor backlog.  Promoting one of these into
 #: ``REGISTRY`` means removing its entry here (the guard fails on the overlap,
 #: telling you the move is done).
-INVENTORY_BACKLOG: dict[Surface, dict[str, int]] = {
+INVENTORY_BACKLOG: dict[Surface, dict[str, int | InventoryBacklogEntry]] = {
     "mcp": {
         "palinode_dedup_suggest": 170,
         "palinode_diff": 170,
         "palinode_entities": 170,
-        "palinode_history": 170,
+        "palinode_history": InventoryBacklogEntry(170, aliases=("palinode_timeline",)),
         "palinode_ingest": 170,
         "palinode_lint": 170,
         "palinode_orphan_repair": 170,
         "palinode_prompt": 170,
         "palinode_push": 170,
         "palinode_session_end": 170,
-        "palinode_timeline": 170,
     },
     "api": {
         "DELETE /triggers/{trigger_id}": 170,
@@ -727,6 +734,15 @@ def registered_capabilities(surface: Surface) -> frozenset[str]:
     return frozenset(ids)
 
 
+def inventory_backlog_capabilities(surface: Surface) -> frozenset[str]:
+    """Return canonical backlog identifiers plus their alternate names."""
+    capabilities = set(INVENTORY_BACKLOG[surface])
+    for entry in INVENTORY_BACKLOG[surface].values():
+        if isinstance(entry, InventoryBacklogEntry):
+            capabilities.update(entry.aliases)
+    return frozenset(capabilities)
+
+
 def by_name(op_name: str) -> Operation:
     """Look up an operation by name.  Raises ``KeyError`` if missing."""
     for op in REGISTRY:
@@ -746,6 +762,7 @@ __all__ = [
     "CATEGORIES",
     "CanonicalParam",
     "INVENTORY_BACKLOG",
+    "InventoryBacklogEntry",
     "INVENTORY_INFRA",
     "MEMORY_TYPES",
     "Operation",
@@ -754,6 +771,7 @@ __all__ = [
     "REGISTRY",
     "Surface",
     "by_name",
+    "inventory_backlog_capabilities",
     "registered_capabilities",
     "required_surfaces",
 ]

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -40,11 +40,13 @@ from palinode.core.parity import (
     CATEGORIES,
     INVENTORY_BACKLOG,
     INVENTORY_INFRA,
+    InventoryBacklogEntry,
     MEMORY_TYPES,
     REGISTRY,
     CanonicalParam,
     Operation,
     Surface,
+    inventory_backlog_capabilities,
     registered_capabilities,
     required_surfaces,
 )
@@ -560,7 +562,7 @@ def test_no_unregistered_capabilities(surface: Surface) -> None:
     accounted = (
         registered_capabilities(surface)
         | INVENTORY_INFRA[surface]
-        | set(INVENTORY_BACKLOG[surface])
+        | inventory_backlog_capabilities(surface)
     )
     unaccounted = live - accounted
     assert not unaccounted, (
@@ -581,7 +583,7 @@ def test_inventory_accounting_is_not_stale(surface: Surface) -> None:
     hygiene rule).
     """
     live = _LIVE_CAPABILITIES[surface]()
-    stale = (INVENTORY_INFRA[surface] | set(INVENTORY_BACKLOG[surface])) - live
+    stale = (INVENTORY_INFRA[surface] | inventory_backlog_capabilities(surface)) - live
     assert not stale, (
         f"{surface}: inventory-accounting entries no longer present on the "
         f"surface: {sorted(stale)}. Remove them from INVENTORY_INFRA / "
@@ -593,7 +595,7 @@ def test_inventory_accounting_is_not_stale(surface: Surface) -> None:
 def test_inventory_buckets_are_disjoint(surface: Surface) -> None:
     """A capability is classified once: infra XOR backlog XOR registered."""
     infra = INVENTORY_INFRA[surface]
-    backlog = set(INVENTORY_BACKLOG[surface])
+    backlog = inventory_backlog_capabilities(surface)
     registered = registered_capabilities(surface)
     assert not (infra & backlog), (
         f"{surface}: in both INVENTORY_INFRA and INVENTORY_BACKLOG: "
@@ -607,3 +609,13 @@ def test_inventory_buckets_are_disjoint(surface: Surface) -> None:
         f"{surface}: a registered operation is also marked infra: "
         f"{sorted(registered & infra)}"
     )
+
+
+def test_inventory_alias_does_not_add_a_capability_row() -> None:
+    """An alternate name annotates its canonical row instead of inflating inventory."""
+    history = INVENTORY_BACKLOG["mcp"]["palinode_history"]
+
+    assert history == InventoryBacklogEntry(170, aliases=("palinode_timeline",))
+    assert "palinode_timeline" not in INVENTORY_BACKLOG["mcp"]
+    assert "palinode_timeline" in inventory_backlog_capabilities("mcp")
+    assert len(inventory_backlog_capabilities("mcp")) == len(INVENTORY_BACKLOG["mcp"]) + 1


### PR DESCRIPTION
## Summary

- represent backlog entries that have alternate surface names with an `InventoryBacklogEntry`
- annotate `palinode_timeline` as an alias of the canonical `palinode_history` MCP inventory row
- keep aliases in live/stale/disjoint surface validation without counting them as capability rows
- document the inventory alias rule and pin it with a focused regression test

The runtime tool registration and deprecation behavior of `palinode_timeline` are unchanged.

## Validation

- `ruff check palinode/core/parity.py tests/test_surface_parity.py`
- full test suite: 3041 passed, 10 skipped, 5 xfailed
- focused parity/MCP tests: 257 passed, 1 xfailed
- Bandit: no medium/high findings
- `git diff --check`

Closes #99
