### PR TITLE
feat(migrate): import bullet-list exports

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Added
 
+- **Deterministic bullet-list migration** adds `palinode migrate bullets FILE`
+  for flat mem0-style exports, grouping leading undated bullets and subsequent
+  dated bullets into sections before reusing the existing migration writer.
 - **Relative-date lint findings** flag the finite set of unanchored time
   expressions that become misleading as living memories age, while exempting
   dated `daily/` notes and reporting each expression with its source line.

--- a/palinode/cli/migrate.py
+++ b/palinode/cli/migrate.py
@@ -36,6 +36,33 @@ def _interactive_review(sections: list[dict]) -> list[dict]:
     return reviewed
 
 
+def _print_migration_result(result: dict, dry_run: bool, source_name: str) -> None:
+    """Render the shared human-readable migration result contract."""
+    prefix = "[yellow](dry-run)[/yellow] " if dry_run else ""
+    console.print(f"\n{prefix}[bold]{source_name} migration complete[/bold]")
+    console.print(f"  Sections found:  {result['sections_found']}")
+    console.print(f"  Files created:   {len(result['files_created'])}")
+    console.print(f"  Files skipped:   {len(result['files_skipped'])} (duplicate content)")
+
+    if result["files_created"]:
+        console.print("\n[green]Created:[/green]")
+        for fp in result["files_created"]:
+            console.print(f"  {fp}")
+
+    if result["files_skipped"]:
+        console.print("\n[dim]Skipped (identical content already exists):[/dim]")
+        for fp in result["files_skipped"]:
+            console.print(f"  {fp}")
+
+    if result.get("log_file"):
+        console.print(f"\n[dim]Migration log:[/dim] {result['log_file']}")
+
+    if dry_run:
+        console.print(
+            "\n[yellow]Dry run — no files written. Remove --dry-run to import.[/yellow]"
+        )
+
+
 @migrate.command(name="openclaw")
 @click.argument("memory_file", type=click.Path(exists=True, dir_okay=False, readable=True))
 @click.option("--dry-run", is_flag=True, default=False, help="Show what would be imported without writing files")
@@ -70,30 +97,32 @@ def openclaw(memory_file: str, dry_run: bool, review: bool, fmt: str | None) -> 
         print_result(result, fmt=output_fmt)
         return
 
-    # Human-readable output
-    prefix = "[yellow](dry-run)[/yellow] " if dry_run else ""
-    console.print(f"\n{prefix}[bold]OpenClaw migration complete[/bold]")
-    console.print(f"  Sections found:  {result['sections_found']}")
-    console.print(f"  Files created:   {len(result['files_created'])}")
-    console.print(f"  Files skipped:   {len(result['files_skipped'])} (duplicate content)")
+    _print_migration_result(result, dry_run, "OpenClaw")
 
-    if result["files_created"]:
-        console.print("\n[green]Created:[/green]")
-        for fp in result["files_created"]:
-            console.print(f"  {fp}")
 
-    if result["files_skipped"]:
-        console.print("\n[dim]Skipped (identical content already exists):[/dim]")
-        for fp in result["files_skipped"]:
-            console.print(f"  {fp}")
+@migrate.command(name="bullets")
+@click.argument("memory_file", type=click.Path(exists=True, dir_okay=False, readable=True))
+@click.option("--dry-run", is_flag=True, default=False, help="Show what would be imported without writing files")
+@click.option("--format", "fmt", type=click.Choice(["text", "json"]), help="Output format")
+def bullets(memory_file: str, dry_run: bool, fmt: str | None) -> None:
+    """Import a flat date-bulleted memory export into Palinode."""
+    from palinode.migration.bullets import run_migration
 
-    if result.get("log_file"):
-        console.print(f"\n[dim]Migration log:[/dim] {result['log_file']}")
+    output_fmt = OutputFormat(fmt) if fmt else get_default_format()
+    try:
+        result = run_migration(source_path=memory_file, dry_run=dry_run)
+    except ValueError as exc:
+        console.print(f"[red]Error:[/red] {exc}")
+        raise SystemExit(1)
+    except Exception as exc:
+        console.print(f"[red]Migration failed:[/red] {exc}")
+        raise SystemExit(1)
 
-    if dry_run:
-        console.print(
-            "\n[yellow]Dry run — no files written. Remove --dry-run to import.[/yellow]"
-        )
+    if output_fmt == OutputFormat.JSON:
+        print_result(result, fmt=output_fmt)
+        return
+
+    _print_migration_result(result, dry_run, "Bullet-list")
 
 
 @migrate.command(name="frontmatter")

--- a/palinode/core/parity.py
+++ b/palinode/core/parity.py
@@ -623,6 +623,7 @@ INVENTORY_INFRA: dict[Surface, frozenset[str]] = {
             "init",
             "mcp-config",
             "mcp-smoke",
+            "migrate bullets",
             "migrate frontmatter",
             "migrate openclaw",
             "migrate-mem0",

--- a/palinode/migration/bullets.py
+++ b/palinode/migration/bullets.py
@@ -1,0 +1,70 @@
+"""Deterministic migration for flat, date-prefixed bullet-list exports."""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from palinode.migration.openclaw import (
+    _detect_type,
+    _slugify,
+    _validate_source_path,
+    run_sections_migration,
+)
+
+_BULLET = re.compile(r"^\s*[-*]\s+(?:(\d{4}-\d{2}-\d{2})\s+)?(.+?)\s*$")
+_UNDATED_HEADING = "Undated memories"
+
+
+def _section(heading: str, items: list[str]) -> dict[str, Any]:
+    body = "\n".join(f"- {item}" for item in items)
+    return {
+        "heading": heading,
+        "body": body,
+        "type": _detect_type(heading, body),
+        "slug": _slugify(heading),
+    }
+
+
+def _parse_raw(raw: str) -> list[dict[str, Any]]:
+    """Group bullets into a leading undated section and date sections."""
+    undated_items: list[str] = []
+    dated_items: dict[str, list[str]] = {}
+    current_date: str | None = None
+
+    for line in raw.splitlines():
+        match = _BULLET.match(line)
+        if match is None:
+            continue
+        date, text = match.groups()
+        if date is not None:
+            current_date = date
+        if current_date is None:
+            undated_items.append(text)
+        else:
+            dated_items.setdefault(current_date, []).append(text)
+
+    sections: list[dict[str, Any]] = []
+    if undated_items:
+        sections.append(_section(_UNDATED_HEADING, undated_items))
+    sections.extend(_section(date, items) for date, items in dated_items.items())
+    return sections
+
+
+def parse_bullet_list(source_path: str) -> list[dict[str, Any]]:
+    """Parse a bullet-list export into the canonical migration section shape."""
+    validated = _validate_source_path(source_path)
+    with open(validated, "r", encoding="utf-8") as source:
+        return _parse_raw(source.read())
+
+
+def run_migration(source_path: str, dry_run: bool = False) -> dict[str, Any]:
+    """Import a flat bullet-list export through the shared migration writer."""
+    validated = _validate_source_path(source_path)
+    sections = parse_bullet_list(validated)
+    return run_sections_migration(
+        validated,
+        sections,
+        source_name="bullets",
+        display_name="Bullet-list",
+        dry_run=dry_run,
+    )

--- a/palinode/migration/openclaw.py
+++ b/palinode/migration/openclaw.py
@@ -156,6 +156,7 @@ def _build_file_content(
     section: dict[str, Any],
     now_iso: str,
     source_path: str,
+    source_name: str = "openclaw",
 ) -> tuple[str, str]:
     """Return (relative_path, file_content) for a section.
 
@@ -171,7 +172,7 @@ def _build_file_content(
         "category": subdir,
         "name": section["heading"],
         "last_updated": now_iso,
-        "source": "openclaw-migration",
+        "source": f"{source_name}-migration",
         "source_file": os.path.basename(source_path),
     }
     fm_str = yaml.dump(frontmatter, default_flow_style=False, allow_unicode=True)
@@ -179,7 +180,12 @@ def _build_file_content(
     return rel_path, content
 
 
-def _git_commit(memory_dir: str, staged_files: list[str], log_file: str | None) -> None:
+def _git_commit(
+    staged_files: list[str],
+    log_file: str | None,
+    source_name: str,
+    source_path: str,
+) -> None:
     """Commit each migrated file in its own per-file commit.
 
     Each imported section is a genesis mutation, so each created memory gets its
@@ -193,13 +199,105 @@ def _git_commit(memory_dir: str, staged_files: list[str], log_file: str | None) 
             continue
         base = os.path.basename(fp)
         git_tools.commit_memory_file(
-            fp, f"palinode migrate openclaw: import {base} from MEMORY.md ({date_str})"
+            fp,
+            f"palinode migrate {source_name}: import {base} from "
+            f"{os.path.basename(source_path)} ({date_str})",
         )
     if log_file:
         git_tools.commit_memory_file(
             log_file,
-            f"palinode migrate openclaw: import log ({date_str})",
+            f"palinode migrate {source_name}: import log ({date_str})",
         )
+
+
+def run_sections_migration(
+    source_path: str,
+    sections: list[dict[str, Any]],
+    *,
+    source_name: str,
+    display_name: str,
+    dry_run: bool = False,
+    review_callback: Callable[[list[dict[str, Any]]], list[dict[str, Any]]] | None = None,
+) -> dict[str, Any]:
+    """Write parsed sections through the canonical migration path."""
+    memory_dir = os.path.realpath(config.memory_dir)
+    validated_source = _validate_source_path(source_path)
+
+    if review_callback is not None:
+        sections = review_callback(sections)
+
+    now_iso = datetime.now(UTC).isoformat()
+    existing_hashes: set[str] = set() if dry_run else _existing_hashes(memory_dir)
+
+    files_created: list[str] = []
+    files_skipped: list[str] = []
+    written_abs: list[str] = []
+
+    for section in sections:
+        rel_path, content = _build_file_content(
+            section,
+            now_iso,
+            validated_source,
+            source_name,
+        )
+        content_hash = _sha256(content)
+
+        if content_hash in existing_hashes:
+            files_skipped.append(rel_path)
+            continue
+
+        if dry_run:
+            files_created.append(rel_path)
+            continue
+
+        abs_path = os.path.join(memory_dir, rel_path)
+        os.makedirs(os.path.dirname(abs_path), exist_ok=True)
+        git_tools.write_memory_file(abs_path, content)
+
+        existing_hashes.add(content_hash)
+        files_created.append(rel_path)
+        written_abs.append(abs_path)
+        logger.info("Created %s", rel_path)
+
+    log_rel: str | None = None
+    log_abs: str | None = None
+    if not dry_run and (files_created or files_skipped):
+        date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+        log_rel = f"migrations/{source_name}-{date_str}.md"
+        log_abs = os.path.join(memory_dir, log_rel)
+        os.makedirs(os.path.dirname(log_abs), exist_ok=True)
+
+        log_lines = [
+            f"# {display_name} Migration — {date_str}",
+            "",
+            f"Source: `{os.path.basename(validated_source)}`",
+            f"Sections found: {len(sections)}",
+            f"Files created: {len(files_created)}",
+            f"Files skipped (dedup): {len(files_skipped)}",
+            "",
+            "## Created",
+            "",
+        ]
+        for fp in files_created:
+            log_lines.append(f"- `{fp}`")
+        if files_skipped:
+            log_lines.extend(["", "## Skipped (duplicate content)", ""])
+            for fp in files_skipped:
+                log_lines.append(f"- `{fp}`")
+        log_lines.append("")
+
+        git_tools.write_memory_file(log_abs, "\n".join(log_lines))
+
+    if not dry_run and written_abs:
+        _git_commit(written_abs, log_abs, source_name, validated_source)
+
+    return {
+        "sections_found": len(sections),
+        "files_created": files_created,
+        "files_skipped": files_skipped,
+        "log_file": log_rel,
+        "dry_run": dry_run,
+    }
 
 
 def run_migration(
@@ -225,84 +323,15 @@ def run_migration(
             log_file: str | None       — relative path of the migration log
             dry_run: bool
     """
-    memory_dir = os.path.realpath(config.memory_dir)
     validated_source = _validate_source_path(source_path)
 
     with open(validated_source, "r", encoding="utf-8") as f:
         sections = _parse_raw(f.read())
-
-    if review_callback is not None:
-        sections = review_callback(sections)
-
-    # timezone-aware UTC ISO-8601 (``+00:00``). The previous
-    # ``strftime("...Z")`` form emitted UTC stamped as ``Z`` and dropped
-    # sub-second precision — switch to the project timestamp standard.
-    now_iso = datetime.now(UTC).isoformat()
-
-    existing_hashes: set[str] = set() if dry_run else _existing_hashes(memory_dir)
-
-    files_created: list[str] = []
-    files_skipped: list[str] = []
-    written_abs: list[str] = []
-
-    for section in sections:
-        rel_path, content = _build_file_content(section, now_iso, validated_source)
-        content_hash = _sha256(content)
-
-        if content_hash in existing_hashes:
-            files_skipped.append(rel_path)
-            continue
-
-        if dry_run:
-            files_created.append(rel_path)
-            continue
-
-        abs_path = os.path.join(memory_dir, rel_path)
-        os.makedirs(os.path.dirname(abs_path), exist_ok=True)
-        git_tools.write_memory_file(abs_path, content)
-
-        existing_hashes.add(content_hash)
-        files_created.append(rel_path)
-        written_abs.append(abs_path)
-        logger.info(f"Created {rel_path}")
-
-    # Write migration log
-    log_rel: str | None = None
-    log_abs: str | None = None
-    if not dry_run and (files_created or files_skipped):
-        date_str = datetime.now(UTC).strftime("%Y-%m-%d")
-        log_rel = f"migrations/openclaw-{date_str}.md"
-        log_abs = os.path.join(memory_dir, log_rel)
-        os.makedirs(os.path.dirname(log_abs), exist_ok=True)
-
-        log_lines = [
-            f"# OpenClaw Migration — {date_str}",
-            "",
-            f"Source: `{os.path.basename(validated_source)}`",
-            f"Sections found: {len(sections)}",
-            f"Files created: {len(files_created)}",
-            f"Files skipped (dedup): {len(files_skipped)}",
-            "",
-            "## Created",
-            "",
-        ]
-        for fp in files_created:
-            log_lines.append(f"- `{fp}`")
-        if files_skipped:
-            log_lines.extend(["", "## Skipped (duplicate content)", ""])
-            for fp in files_skipped:
-                log_lines.append(f"- `{fp}`")
-        log_lines.append("")
-
-        git_tools.write_memory_file(log_abs, "\n".join(log_lines))
-
-    if not dry_run and written_abs:
-        _git_commit(memory_dir, written_abs, log_abs)
-
-    return {
-        "sections_found": len(sections),
-        "files_created": files_created,
-        "files_skipped": files_skipped,
-        "log_file": log_rel,
-        "dry_run": dry_run,
-    }
+    return run_sections_migration(
+        validated_source,
+        sections,
+        source_name="openclaw",
+        display_name="OpenClaw",
+        dry_run=dry_run,
+        review_callback=review_callback,
+    )

--- a/tests/fixtures/bullet_memories.md
+++ b/tests/fixtures/bullet_memories.md
@@ -1,0 +1,7 @@
+- No leading date at all.
+- Another undated memory about a project task.
+- 2026-03-01 Prefers dark roast, drinks it black.
+- 2026-03-01 Works in the Berlin office on Tuesdays.
+- 2026-03-14 Decided to drop the Redis dependency.
+* 2026-03-14 Alternative bullet marker, same meaning.
+- An undated continuation stays with the current date.

--- a/tests/test_migrate_bullets.py
+++ b/tests/test_migrate_bullets.py
@@ -1,0 +1,114 @@
+"""Flat bullet-list migration parsing and CLI contracts."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from palinode.cli import main
+from palinode.core.config import config
+from palinode.migration.bullets import _parse_raw, parse_bullet_list, run_migration
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "bullet_memories.md"
+
+
+def test_parser_groups_leading_undated_and_date_boundaries() -> None:
+    sections = parse_bullet_list(str(FIXTURE))
+
+    assert [section["heading"] for section in sections] == [
+        "Undated memories",
+        "2026-03-01",
+        "2026-03-14",
+    ]
+    assert sections[0]["body"].splitlines() == [
+        "- No leading date at all.",
+        "- Another undated memory about a project task.",
+    ]
+    assert sections[1]["body"].count("\n") == 1
+    assert "Alternative bullet marker" in sections[2]["body"]
+    assert "undated continuation" in sections[2]["body"]
+    assert sections[2]["type"] == "decision"
+
+
+def test_empty_file_is_a_clean_noop(tmp_path: Path) -> None:
+    source = tmp_path / "empty.md"
+    source.write_text("", encoding="utf-8")
+
+    assert parse_bullet_list(str(source)) == []
+    result = run_migration(str(source), dry_run=True)
+    assert result == {
+        "sections_found": 0,
+        "files_created": [],
+        "files_skipped": [],
+        "log_file": None,
+        "dry_run": True,
+    }
+
+
+def test_repeated_date_is_merged_without_duplicate_output_paths() -> None:
+    sections = _parse_raw(
+        "- 2026-03-01 First memory.\n"
+        "- 2026-03-14 Different date.\n"
+        "- 2026-03-01 Later memory for the first date.\n"
+    )
+
+    assert [section["heading"] for section in sections] == [
+        "2026-03-01",
+        "2026-03-14",
+    ]
+    assert sections[0]["body"].splitlines() == [
+        "- First memory.",
+        "- Later memory for the first date.",
+    ]
+
+
+def test_cli_dry_run_reports_sections_without_writing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    monkeypatch.setattr(config, "memory_dir", str(memory_dir))
+
+    result = CliRunner().invoke(
+        main,
+        ["migrate", "bullets", str(FIXTURE), "--dry-run", "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["sections_found"] == 3
+    assert len(payload["files_created"]) == 3
+    assert payload["dry_run"] is True
+    assert list(memory_dir.iterdir()) == []
+
+
+def test_migration_reuses_writer_with_bullet_provenance(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    monkeypatch.setattr(config, "memory_dir", str(memory_dir))
+    monkeypatch.setattr(config.git, "auto_commit", False)
+
+    result = run_migration(str(FIXTURE))
+
+    assert result["sections_found"] == 3
+    assert len(result["files_created"]) == 3
+    assert result["log_file"].startswith("migrations/bullets-")
+    for relative_path in result["files_created"]:
+        content = (memory_dir / relative_path).read_text(encoding="utf-8")
+        assert "source: bullets-migration" in content
+    log = (memory_dir / result["log_file"]).read_text(encoding="utf-8")
+    assert "# Bullet-list Migration" in log
+    assert "Sections found: 3" in log
+
+
+def test_cli_and_inventory_expose_bullet_migration() -> None:
+    from palinode.core.parity import INVENTORY_INFRA
+
+    assert "bullets" in main.commands["migrate"].commands
+    assert "migrate bullets" in INVENTORY_INFRA["cli"]


### PR DESCRIPTION
## Summary

- add `palinode migrate bullets FILE` for deterministic flat bullet-list imports
- group leading undated memories and date-prefixed memories into canonical migration sections, including repeated dates
- extract and reuse OpenClaw's write, deduplication, provenance, log, and git-commit path
- preserve the existing OpenClaw CLI and migration contracts
- add parser, fixture, dry-run, writer, CLI, and parity coverage

## Why

Flat mem0-style exports cannot be consumed by the structured OpenClaw importer. This adds the requested model-free file import path without creating a second persistence implementation.

## Validation

- `ruff check palinode/ tests/ scripts/`
- `python -m pytest tests/test_migrate_bullets.py tests/test_migrate_openclaw.py tests/test_surface_parity.py tests/test_parity_is_dependency_free.py -q` (249 passed, 1 xfailed)
- `python -m pytest tests/ -q --tb=short --ignore=tests/integration` (2928 passed, 9 skipped, 5 xfailed)
- `python -m compileall -q palinode tests/test_migrate_bullets.py`
- `git diff --check`

Closes #75

AI-assisted: Codex was used to help implement and validate this change; the resulting diff and tests were reviewed locally.
