### PR TITLE
fix: deduplicate API timeline parity alias

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Palinode. Format follows [Keep a Changelog](https://keepa
 
 ### Fixed
 
+- **API parity inventory counts the deprecated `/timeline` alias once (#122).** The alias now annotates the canonical `/history` backlog entry while remaining available at runtime.
 - **CLI parity inventory counts the deprecated `timeline` alias once (#120).** The alias now annotates the canonical `history` backlog entry while remaining available at runtime.
 - **Parity inventory no longer counts the deprecated `palinode_timeline` alias as a separate capability (#99).** The alias now annotates the canonical `palinode_history` backlog entry while remaining live and deprecated at runtime.
 

--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -136,7 +136,7 @@ Identifier form per surface: MCP = tool name (`palinode_search`); API = `METHOD 
 
 These memory-semantic operations ship on all of MCP/API/CLI today but are not yet promoted into `REGISTRY` with canonical params. They are tracked under #170 (admin/framework surface is in `INVENTORY_INFRA`, not here):
 
-`dedup_suggest`, `diff`, `entities`, `history` (including the deprecated MCP `palinode_timeline` and CLI `timeline` aliases), `ingest`/`ingest-url`, `lint`, `orphan_repair`, `prompt` (list/show/activate), `push`, `session_end`, and the trigger `list`/`remove` + `check-triggers` + `search-associative` API endpoints. `depends/_unblocked` is tracked under #97.
+`dedup_suggest`, `diff`, `entities`, `history` (including the deprecated MCP `palinode_timeline`, CLI `timeline`, and API `GET /timeline/{file_path:path}` aliases), `ingest`/`ingest-url`, `lint`, `orphan_repair`, `prompt` (list/show/activate), `push`, `session_end`, and the trigger `list`/`remove` + `check-triggers` + `search-associative` API endpoints. `depends/_unblocked` is tracked under #97.
 
 Promoting each (registry `Operation` + canonical params + removing its backlog entry) is the per-op work the issue tracks; this contract makes the gap explicit and prevents *new* unregistered ops from slipping in alongside them.
 

--- a/palinode/core/parity.py
+++ b/palinode/core/parity.py
@@ -675,10 +675,11 @@ INVENTORY_BACKLOG: dict[Surface, dict[str, int | InventoryBacklogEntry]] = {
         "GET /diff": 170,
         "GET /entities": 170,
         "GET /entities/{entity_ref:path}": 170,
-        "GET /history/{file_path:path}": 170,
+        "GET /history/{file_path:path}": InventoryBacklogEntry(
+            170, aliases=("GET /timeline/{file_path:path}",)
+        ),
         "GET /prompts": 170,
         "GET /prompts/{name}": 170,
-        "GET /timeline/{file_path:path}": 170,
         "POST /check-triggers": 170,
         "POST /dedup-suggest": 170,
         "POST /ingest": 170,

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -629,3 +629,15 @@ def test_cli_inventory_alias_does_not_add_a_capability_row() -> None:
     assert "timeline" not in INVENTORY_BACKLOG["cli"]
     assert "timeline" in inventory_backlog_capabilities("cli")
     assert len(inventory_backlog_capabilities("cli")) == len(INVENTORY_BACKLOG["cli"]) + 1
+
+
+def test_api_inventory_alias_does_not_add_a_capability_row() -> None:
+    """The deprecated API alias annotates history instead of inflating inventory."""
+    history = INVENTORY_BACKLOG["api"]["GET /history/{file_path:path}"]
+
+    assert history == InventoryBacklogEntry(
+        170, aliases=("GET /timeline/{file_path:path}",)
+    )
+    assert "GET /timeline/{file_path:path}" not in INVENTORY_BACKLOG["api"]
+    assert "GET /timeline/{file_path:path}" in inventory_backlog_capabilities("api")
+    assert len(inventory_backlog_capabilities("api")) == len(INVENTORY_BACKLOG["api"]) + 1


### PR DESCRIPTION
## Summary
- record the deprecated API timeline route as an alias of the canonical history backlog entry
- cover alias accounting with a focused regression test
- document the API alias and add the required changelog entry

Closes #122.

## Verification
- RED: `tests/test_surface_parity.py::test_api_inventory_alias_does_not_add_a_capability_row` failed against the standalone alias row
- GREEN: `pytest tests/test_surface_parity.py -q` - 223 passed, 1 expected xfail
- `ruff check palinode/ tests/ scripts/` - passed
- `bandit -r palinode/ -ll` - no issues identified
- Full `pytest -q`: 3024 passed; 9 existing hook-script failures require `jq`, which is unavailable in this environment; this change does not touch those files.