### PR TITLE
fix(parity): annotate the API /timeline alias instead of double-counting it

### DIFF
--- a/docs/PARITY.md
+++ b/docs/PARITY.md
@@ -136,7 +136,7 @@ Identifier form per surface: MCP = tool name (`palinode_search`); API = `METHOD 
 
 These memory-semantic operations ship on all of MCP/API/CLI today but are not yet promoted into `REGISTRY` with canonical params. They are tracked under #170 (admin/framework surface is in `INVENTORY_INFRA`, not here):
 
-`dedup_suggest`, `diff`, `entities`, `history` (including the deprecated MCP `palinode_timeline` and CLI `timeline` aliases), `ingest`/`ingest-url`, `lint`, `orphan_repair`, `prompt` (list/show/activate), `push`, `session_end`, and the trigger `list`/`remove` + `check-triggers` + `search-associative` API endpoints. `depends/_unblocked` is tracked under #97.
+`dedup_suggest`, `diff`, `entities`, `history` (including the deprecated MCP `palinode_timeline`, CLI `timeline`, and API `GET /timeline/{file_path:path}` aliases), `ingest`/`ingest-url`, `lint`, `orphan_repair`, `prompt` (list/show/activate), `push`, `session_end`, and the trigger `list`/`remove` + `check-triggers` + `search-associative` API endpoints. `depends/_unblocked` is tracked under #97.
 
 Promoting each (registry `Operation` + canonical params + removing its backlog entry) is the per-op work the issue tracks; this contract makes the gap explicit and prevents *new* unregistered ops from slipping in alongside them.
 

--- a/palinode/core/parity.py
+++ b/palinode/core/parity.py
@@ -675,10 +675,11 @@ INVENTORY_BACKLOG: dict[Surface, dict[str, int | InventoryBacklogEntry]] = {
         "GET /diff": 170,
         "GET /entities": 170,
         "GET /entities/{entity_ref:path}": 170,
-        "GET /history/{file_path:path}": 170,
+        "GET /history/{file_path:path}": InventoryBacklogEntry(
+            170, aliases=("GET /timeline/{file_path:path}",)
+        ),
         "GET /prompts": 170,
         "GET /prompts/{name}": 170,
-        "GET /timeline/{file_path:path}": 170,
         "POST /check-triggers": 170,
         "POST /dedup-suggest": 170,
         "POST /ingest": 170,

--- a/tests/test_surface_parity.py
+++ b/tests/test_surface_parity.py
@@ -629,3 +629,15 @@ def test_cli_inventory_alias_does_not_add_a_capability_row() -> None:
     assert "timeline" not in INVENTORY_BACKLOG["cli"]
     assert "timeline" in inventory_backlog_capabilities("cli")
     assert len(inventory_backlog_capabilities("cli")) == len(INVENTORY_BACKLOG["cli"]) + 1
+
+
+def test_api_inventory_alias_does_not_add_a_capability_row() -> None:
+    """The deprecated API /timeline alias annotates history instead of inflating inventory."""
+    history = INVENTORY_BACKLOG["api"]["GET /history/{file_path:path}"]
+
+    assert history == InventoryBacklogEntry(
+        170, aliases=("GET /timeline/{file_path:path}",)
+    )
+    assert "GET /timeline/{file_path:path}" not in INVENTORY_BACKLOG["api"]
+    assert "GET /timeline/{file_path:path}" in inventory_backlog_capabilities("api")
+    assert len(inventory_backlog_capabilities("api")) == len(INVENTORY_BACKLOG["api"]) + 1


### PR DESCRIPTION
## What this PR does

`GET /timeline/{file_path:path}` is deprecated in favour of
`GET /history/{file_path:path}?detail=full` (the handler already logs this
and the history route's own docstring says as much), but
`INVENTORY_BACKLOG["api"]` still carried both as separate rows, so the
parity inventory counted one capability twice. This is the same defect
already fixed for the MCP surface (#118) and the CLI surface (#121) — this
is the matching fix for the last timeline surface.

Per the issue's own "decisions already made": annotates the canonical
`GET /history/{file_path:path}` row with the alias via
`InventoryBacklogEntry` instead of deleting or promoting anything. No
change to the route handler or its deprecation logging. Updated
`docs/PARITY.md`'s backlog paragraph to list the API alias alongside the
MCP/CLI ones already there.

Closes #122

## Testing

- [x] `python -m pytest tests/test_surface_parity.py -q` — 223 passed,
      1 xfailed (pre-existing, unrelated)
- [x] Added `test_api_inventory_alias_does_not_add_a_capability_row`
      alongside the existing MCP/CLI alias tests, same assertion shape
- [x] The three existing inventory guards
      (`test_no_unregistered_capabilities`,
      `test_inventory_accounting_is_not_stale`,
      `test_inventory_buckets_are_disjoint`) still pass unmodified